### PR TITLE
Upgrade to pyproj 2.2.1

### DIFF
--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -2,7 +2,7 @@ pytest
 PyYAML>=5.1
 requests
 psycopg2
-pyproj>=2.1.3
+pyproj>=2.2.1
 tqdm
 xlrd
 

--- a/src/tests/integration/test_nycdb.py
+++ b/src/tests/integration/test_nycdb.py
@@ -152,8 +152,8 @@ def test_pluto_insert(conn):
         assert rec is not None
         assert rec['address'] == '369 PARK AVENUE SOUTH'
         assert rec['lotarea'] == 8032
-        assert round(rec['lng'], 12) == -73.984339547978
-        assert round(rec['lat'], 12) == 40.742121844634
+        assert round(rec['lng'], 12) == -73.984338104629
+        assert round(rec['lat'], 12) == 40.74211358173
 
 
 def test_pluto17v1(conn):

--- a/src/tests/unit/test_transform.py
+++ b/src/tests/unit/test_transform.py
@@ -63,5 +63,5 @@ def test_skip_fields():
 
 def test_ny_state_coords_to_lat_lng():
     coords = [988590, 209649]
-    result = (-73.98433954797815, 40.742121844633694)
+    result = (-73.98433810462848, 40.74211358173024)
     assert nycdb.transform.ny_state_coords_to_lat_lng(*coords) == result


### PR DESCRIPTION
Arg, it seems like pyproj's algorithm for coordinate transformations keeps changing and breaking our tests. Judging by the previous pyproj changes in #90, it looks like perhaps the maintainers noticed a regression and reverted transformations back to the way they worked before version 2.1.3, but I'm not sure.

In any case, this fixes our tests at least.
