### PR TITLE
fix pyproj test failure & move pyproj function into module named geo

### DIFF
--- a/src/nycdb/__init__.py
+++ b/src/nycdb/__init__.py
@@ -4,7 +4,7 @@ __version__ = '0.1.0'
 __author__ = 'ziggy <ziggy@elephant-bird.net>'
 #__all__ = []
 
-from . import typecast, sql, transform, bbl, dof_parser, address
+from . import typecast, sql, transform, bbl, dof_parser, address, geo
 from .database import Database
 from .dataset import Dataset
 from .datasets import datasets

--- a/src/nycdb/geo.py
+++ b/src/nycdb/geo.py
@@ -1,0 +1,11 @@
+import pyproj
+
+p4j = '+proj=lcc +lat_1=40.66666666666666 +lat_2=41.03333333333333 +lat_0=40.16666666666666 +lon_0=-74 +x_0=300000 +y_0=0 +datum=NAD83 +units=us-ft +no_defs'
+ny_state_plane = pyproj.Proj(p4j, preserve_units=True)
+wgs84 = pyproj.Proj(init="epsg:4326")
+transformer = pyproj.Transformer.from_proj(ny_state_plane, wgs84)
+
+def ny_state_coords_to_lat_lng(xcoord, ycoord):
+    return transformer.transform(xcoord, ycoord)
+
+

--- a/src/nycdb/geo.py
+++ b/src/nycdb/geo.py
@@ -1,11 +1,8 @@
 import pyproj
 
-p4j = '+proj=lcc +lat_1=40.66666666666666 +lat_2=41.03333333333333 +lat_0=40.16666666666666 +lon_0=-74 +x_0=300000 +y_0=0 +datum=NAD83 +units=us-ft +no_defs'
-ny_state_plane = pyproj.Proj(p4j, preserve_units=True)
+ny_state_plane = pyproj.Proj("epsg:2263", preserve_units=True)
 wgs84 = pyproj.Proj(init="epsg:4326")
 transformer = pyproj.Transformer.from_proj(ny_state_plane, wgs84)
 
 def ny_state_coords_to_lat_lng(xcoord, ycoord):
     return transformer.transform(xcoord, ycoord)
-
-

--- a/src/nycdb/transform.py
+++ b/src/nycdb/transform.py
@@ -2,12 +2,12 @@ import csv
 import io
 import re
 import types
-import pyproj
 from zipfile import ZipFile
 
 from .address import normalize_street, normalize_street_number, normalize_apartment
 from .bbl import bbl
 from .utility import merge
+from .geo import ny_state_coords_to_lat_lng
 
 invalid_header_chars = ["\n", "\r", ' ', '-', '#', '.', "'", '"', '_', '/', '(', ')', ':']
 replace_header_chars = [('%', 'pct')]
@@ -38,6 +38,7 @@ def clean_headers(headers):
     """
     str -> [str]
     turns header line into a list and fixes some commmon
+
     issues with column names
     """
     s = headers.lower()
@@ -89,20 +90,9 @@ def to_csv(file_path_or_generator):
             yield row
 
 
-
 def with_bbl(table, borough='borough', block='block', lot='lot'):
     for row in table:
         yield merge(row, {'bbl': bbl(row[borough], row[block], row[lot])})
-
-
-
-p4j = '+proj=lcc +lat_1=40.66666666666666 +lat_2=41.03333333333333 +lat_0=40.16666666666666 +lon_0=-74 +x_0=300000 +y_0=0 +datum=NAD83 +units=us-ft +no_defs '
-ny_state_plane = pyproj.Proj(p4j, preserve_units=True)
-wgs84 = pyproj.Proj(init="epsg:4326")
-transformer = pyproj.Transformer.from_proj(ny_state_plane, wgs84)
-
-def ny_state_coords_to_lat_lng(xcoord, ycoord):
-    return transformer.transform(xcoord, ycoord)
 
 
 def with_geo(table):

--- a/src/tests/integration/test_nycdb.py
+++ b/src/tests/integration/test_nycdb.py
@@ -152,8 +152,8 @@ def test_pluto_insert(conn):
         assert rec is not None
         assert rec['address'] == '369 PARK AVENUE SOUTH'
         assert rec['lotarea'] == 8032
-        assert round(rec['lng'], 12) == -73.984339547978
-        assert round(rec['lat'], 12) == 40.742121844634
+        assert round(rec['lng'], 5) == -73.98434
+        assert round(rec['lat'], 5) == 40.74211
 
 
 def test_pluto17v1(conn):

--- a/src/tests/unit/test_geo.py
+++ b/src/tests/unit/test_geo.py
@@ -1,0 +1,7 @@
+import nycdb
+
+def test_ny_state_coords_to_lat_lng():
+    coords = [987838, 195989]
+    result = nycdb.geo.ny_state_coords_to_lat_lng(*coords)
+    expected = [-73.98706, 40.70462]
+    assert list(map(lambda x: round(x, 5), result)) == expected

--- a/src/tests/unit/test_transform.py
+++ b/src/tests/unit/test_transform.py
@@ -59,9 +59,3 @@ def test_skip_fields():
     fields_to_skip = frozenset(['c'])
     out = list(nycdb.transform.skip_fields(table, fields_to_skip))
     assert out == [{'a': 1, 'b': 2}, {'a': 'x', 'b': 'y'}]
-
-
-def test_ny_state_coords_to_lat_lng():
-    coords = [988590, 209649]
-    result = (-73.98433954797815, 40.742121844633694)
-    assert nycdb.transform.ny_state_coords_to_lat_lng(*coords) == result


### PR DESCRIPTION
changes:

- Static test values are rounded to account for insignificant variation in coordinate coordinate that can happen between pyproj version
- pyproj transformation function moved to module geo
- simplify transformation code