### PR TITLE
Upgrade setuptools and pip in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,8 @@ RUN apt-get update && apt-get install -y \
 	postgresql-client-11 \
         libpq-dev
 
+RUN pip install --upgrade setuptools pip
+
 COPY src/requirements.txt /nycdb/src/requirements.txt
 
 WORKDIR /nycdb/src


### PR DESCRIPTION
I'm not sure exactly what was going on, but when I built the `Dockerfile` from scratch today, attempting to run `nycdb` in the container resulted in the following:

```pytb
Traceback (most recent call last):
  File "/usr/local/bin/nycdb", line 6, in <module>
    from pkg_resources import load_entry_point
  File "/usr/local/lib/python3.6/site-packages/pkg_resources/__init__.py", line 3241, in <module>
    @_call_aside
  File "/usr/local/lib/python3.6/site-packages/pkg_resources/__init__.py", line 3225, in _call_aside
    f(*args, **kwargs)
  File "/usr/local/lib/python3.6/site-packages/pkg_resources/__init__.py", line 3254, in _initialize_master_working_set
    working_set = WorkingSet._build_master()
  File "/usr/local/lib/python3.6/site-packages/pkg_resources/__init__.py", line 583, in _build_master
    ws.require(__requires__)
  File "/usr/local/lib/python3.6/site-packages/pkg_resources/__init__.py", line 900, in require
    needed = self.resolve(parse_requirements(requirements))
  File "/usr/local/lib/python3.6/site-packages/pkg_resources/__init__.py", line 786, in resolve
    raise DistributionNotFound(req, requirers)
pkg_resources.DistributionNotFound: The 'nycdb' distribution was not found and is required by the application
```

I was able to work around this by running `python -m nycdb.cli`.  But when googling for the error, a StackOverflow thread suggested I upgrade setuptools, and once I did this--upgrading from 40.6.3 to 41.0.1--everything seemed to work.  Not really sure exactly _why_ that fixed it but figured I'd add it to the Dockerfile.

I also upgraded the version of `pip` used to stop it from bugging us with "the version of pip you are using is out of date" warnings.
