### PR TITLE
Bugfix/street name normalization

### DIFF
--- a/src/nycdb/address.py
+++ b/src/nycdb/address.py
@@ -5,18 +5,18 @@ in HPD contacts data
 import re
 
 STREETS = [
-    (r'(?<= )AVE(NUE)?', 'AVENUE'),
+    (r'(?<= )AVE(?= |$)', 'AVENUE'),
     (r'(?<= )(STREET|STR|(ST\.?))(?= |$)', 'STREET'),
-    (r'(?<= )PL(ACE)?(?= |$)', 'PLACE'),
+    (r'(?<= )PL(?= |$)', 'PLACE'),
     (r'(?<= )(ROAD|(?<!\d)RD\.?)', 'ROAD'),
-    (r'(?<= )(LA(NE)?|LN)(?= |$)', 'LANE'),
+    (r'(?<= )(LA|LN)(?= |$)', 'LANE'),
     (r'(?<= )CT|CRT', 'COURT'),
     (r'(?<= )DR\.?(?= |$)', 'DRIVE'),
     (r'(?<= )(BOULEVARD|BLVD)', 'BOULEVARD'),
     (r'(?<= )(PKWY|PARKWY)', 'PARKWAY'),
     (r'(?<= )(PK)', 'PARK'),
     (r'(?<= )(BCH)', 'BEACH'),
-    (r'(?<= )TERR(ACE)(?= |$)', 'TERRACE'),
+    (r'(?<= )TERR(?= |$)', 'TERRACE'),
     (r'(^|(?<= ))(BDWAY|BDWY|BROAD WAY)', 'BROADWAY')
 ]
 

--- a/src/nycdb/address.py
+++ b/src/nycdb/address.py
@@ -6,17 +6,17 @@ import re
 
 STREETS = [
     (r'(?<= )AVE(NUE)?', 'AVENUE'),
-    (r'(?<= )(STREET|STR|(ST\.?))', 'STREET'),
-    (r'(?<= )PL(ACE)?', 'PLACE'),
+    (r'(?<= )(STREET|STR|(ST\.?))(?= |$)', 'STREET'),
+    (r'(?<= )PL(ACE)?(?= |$)', 'PLACE'),
     (r'(?<= )(ROAD|(?<!\d)RD\.?)', 'ROAD'),
-    (r'(?<= )(LA(NE)?|LN)', 'LANE'),
+    (r'(?<= )(LA(NE)?|LN)(?= |$)', 'LANE'),
     (r'(?<= )CT|CRT', 'COURT'),
-    (r'(?<= )DR', 'DRIVE'),
+    (r'(?<= )DR\.?(?= |$)', 'DRIVE'),
     (r'(?<= )(BOULEVARD|BLVD)', 'BOULEVARD'),
     (r'(?<= )(PKWY|PARKWY)', 'PARKWAY'),
     (r'(?<= )(PK)', 'PARK'),
     (r'(?<= )(BCH)', 'BEACH'),
-    (r'(?<= )(TERR)', 'TERRACE'),
+    (r'(?<= )TERR(ACE)(?= |$)', 'TERRACE'),
     (r'(^|(?<= ))(BDWAY|BDWY|BROAD WAY)', 'BROADWAY')
 ]
 

--- a/src/tests/unit/test_address.py
+++ b/src/tests/unit/test_address.py
@@ -26,7 +26,7 @@ class TestNormalizeStreet(object):
     def test_place_lane(self):
         assert normalize_street('313 PL N.') == '313TH PLACE NORTH'
         assert normalize_street('302 LN') == '302ND LANE'
-        
+
     def test_street(self):
         assert normalize_street('102nd ST') == '102ND STREET'
         assert normalize_street('E 102nd ST') == 'EAST 102ND STREET'
@@ -34,6 +34,13 @@ class TestNormalizeStreet(object):
         assert normalize_street('W 3rd ST.') == 'WEST THIRD STREET'
         assert normalize_street('S 3rd ST') == 'SOUTH THIRD STREET'
         assert normalize_street('North 10 ST') == 'NORTH TENTH STREET'
+
+        assert normalize_street('RIVERSIDE DRIVE') == 'RIVERSIDE DRIVE'
+        assert normalize_street('RIVERSIDE DR E') == 'RIVERSIDE DRIVE EAST'
+        assert normalize_street('CAMPBELL DR.') == 'CAMPBELL DRIVE'
+        
+
+
 
     def test_ave(self):
         assert normalize_street('AVENUE W') == 'AVENUE W'
@@ -45,7 +52,7 @@ class TestNormalizeStreet(object):
     def test_saints(self):
         assert normalize_street('ST. MARKS') == 'SAINT MARKS'
         assert normalize_street('W. ST JAMES ST.') == 'WEST SAINT JAMES STREET'
-        
+
     def test_aliases(self):
         result = 'ADAM CLAYTON POWELL JR BOULEVARD'
         assert normalize_street('ADAM CLAYTON POWELL') == result
@@ -55,7 +62,7 @@ class TestNormalizeStreet(object):
         assert normalize_street('COLLEGE PT BLVD') == 'COLLEGE POINT BOULEVARD'
         assert normalize_street('COLLEGE PT. BLVD') == 'COLLEGE POINT BOULEVARD'
         assert normalize_street('CO-OP CITY') == 'COOP CITY'
-        
+
 
 def test_normalize_street_number():
     assert normalize_street_number('24') == '24'

--- a/src/tests/unit/test_address.py
+++ b/src/tests/unit/test_address.py
@@ -38,9 +38,9 @@ class TestNormalizeStreet(object):
         assert normalize_street('RIVERSIDE DRIVE') == 'RIVERSIDE DRIVE'
         assert normalize_street('RIVERSIDE DR E') == 'RIVERSIDE DRIVE EAST'
         assert normalize_street('CAMPBELL DR.') == 'CAMPBELL DRIVE'
-        
-
-
+        assert normalize_street('SOME TERRACE') == 'SOME TERRACE'
+        assert normalize_street('SOME PLAZA') == 'SOME PLAZA'
+        assert normalize_street('SOME ST STATION') == 'SOME STREET STATION'
 
     def test_ave(self):
         assert normalize_street('AVENUE W') == 'AVENUE W'


### PR DESCRIPTION
This pull request is a bugfix for Issue #75 

To understand the issue better and test out changes, I looked at Registration_Contacts.csv which is one of the datasets for which we normalize addresses. The cause of the problem is the regex we are using to clean up street names. Specifically, we have a list of abbreviations that we want to replace with the full word, ie ST->STREET. However, the regex catches all words that start with ST, not necessarily just the ST abbreviations. Thus, we get things like STATION->STREETATION. I have added to the expression to make sure that the abbreviation is followed by either a space or end-of-line.

Here are some more unintended results of the original regex in Registration_Contacts.csv. After cleaning and removing duplicates, there were around 21,000 unique streets. A significant number got messed up a bit:
DRIVEI* = 791
PLACEA* = 108 (due to "plaza", "plains")
STREETA* > =100 (mostly due to "station")
STREETE* = 319 (misspellings of "street") 
TERRACEACE - 131
LANE* = a few
AVENUE* = 124 misspellings of avenue

Considerations:
This fix should help with the bug we were seeing. However, cleaning up these street names is definitely a pretty difficult task. Lots of misspellings and other irregularities exist in the datasets that can't really be tracked by regex rules. Is there something we could cross reference these addresses with - maybe some publicly available geocoding data? Or maybe there is already an NLP library for this task.

Also, I found that the normalization function is kind of slow when applied to the entire dataset. However, when I removed duplicate street names from the data before normalizing, it was able to pare it down a lot. I think if we stored a map of unique street name -> normalized street name, then applied that, it would probably be a big speedup.