### PR TITLE
add support for iso8601 dates in typecast

### DIFF
--- a/src/nycdb/typecast.py
+++ b/src/nycdb/typecast.py
@@ -91,8 +91,14 @@ def mm_dd_yyyy(date_str):
 def date(x):
     if isinstance(x, (datetime.date, datetime.datetime)):
         return x
+    # checks for 2018-12-31 date input
+    if re.match(r'\d{4}-\d{1,2}-\d{1,2}', x):
+        try:
+            return datetime.datetime.strptime(x, '%Y-%m-%d').date()
+        except ValueError:
+            return None
     # checks for 20181231 date input
-    if re.match(r'[0-9]{8}', x):
+    elif re.match(r'[0-9]{8}', x):
         try:
             return datetime.datetime.strptime(x, '%Y%m%d').date()
         except ValueError:

--- a/src/tests/unit/test_typecast.py
+++ b/src/tests/unit/test_typecast.py
@@ -64,6 +64,15 @@ def test_date_mm_dd_yyyy():
     assert typecast.date('05/01/1925') == datetime.date(1925, 5, 1)
 
 
+def test_date_iso8601_string():
+    assert typecast.date('1925-05-01') == datetime.date(1925, 5, 1)
+    assert typecast.date('1925-5-1') == datetime.date(1925, 5, 1)
+
+
+def test_date_invalid_iso8601_string():
+    assert typecast.date('1994-02-31') is None
+
+
 def test_date_accepts_datetime():
     assert typecast.date(datetime.date(1925, 5, 1)) == datetime.date(1925, 5, 1)
 


### PR DESCRIPTION
The new OCA data I'm working on uses this format and I saw the "TODO" note that more date formats should be accepted, so thought I would add this. fixes #117 