### PR TITLE
Fix docker-compose setup to avoid DistributionNotFound error

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,6 +4,8 @@ services:
     build: .
     volumes:
       - .:/nycdb
+      # https://stackoverflow.com/a/31373824
+      - /nycdb/src/nycdb.egg-info
     working_dir: /nycdb
     environment:
       - NYCDB_POSTGRES_HOST=db


### PR DESCRIPTION
On some systems, running `nycdb` inside a `docker-compose` shell won't work because the `nycdb.egg-info` folder created in the container when the `Dockerfile` is run  is overwritten by the mounting of the user's host folder.  This causes the following kind of error when running `nycdb` in the container:

```pytb
Traceback (most recent call last):
  File "/usr/local/bin/nycdb", line 6, in <module>
    from pkg_resources import load_entry_point
  File "/usr/local/lib/python3.7/site-packages/pkg_resources/__init__.py", line 3253, in <module>
    @_call_aside
  File "/usr/local/lib/python3.7/site-packages/pkg_resources/__init__.py", line 3237, in _call_aside
    f(*args, **kwargs)
  File "/usr/local/lib/python3.7/site-packages/pkg_resources/__init__.py", line 3266, in _initialize_master_working_set
    working_set = WorkingSet._build_master()
  File "/usr/local/lib/python3.7/site-packages/pkg_resources/__init__.py", line 584, in _build_master
    ws.require(__requires__)
  File "/usr/local/lib/python3.7/site-packages/pkg_resources/__init__.py", line 901, in require
    needed = self.resolve(parse_requirements(requirements))
  File "/usr/local/lib/python3.7/site-packages/pkg_resources/__init__.py", line 787, in resolve
    raise DistributionNotFound(req, requirers)
pkg_resources.DistributionNotFound: The 'nycdb' distribution was not found and is required by the application
```

This fixes the error by mounting `nycdb.egg-info` atop the user's host folder in `docker-compose.yml`.

More details about this fix can be found at https://stackoverflow.com/a/31373824.
