### PR TITLE
Remove superfluous fields from marshal evictions 19 yml

### DIFF
--- a/src/nycdb/datasets/marshal_evictions.yml
+++ b/src/nycdb/datasets/marshal_evictions.yml
@@ -67,8 +67,6 @@ schema:
       CleanedAddress: text
       CourtIndexNumber: text
       DocketNumber: text
-      CleanHouseNum: text
-      CleanStreet: text
       EvictionAddress: text
       EvictionAptNum: text
       EvictionZip: text


### PR DESCRIPTION
Hey friends! After another look, I realized that the fields `cleanhousenum` and `cleanstreet` are not fields that are populated in the 2019 evictions data (although they exist in the 2018 version). My suggestion would be to remove them, as they'll just show up as NULL columns. I could also understand how it may be best practice to keep them for continuity's sake? Let me know your thoughts!