### PR TITLE
add timestamp types and tests for oca

### DIFF
--- a/src/nycdb/datasets/oca.yml
+++ b/src/nycdb/datasets/oca.yml
@@ -88,7 +88,7 @@ schema:
     fields:
       indexnumberid: text
       appearanceid: bigint
-      appearancedatetime: timestamp
+      appearancedatetime: 'timestamp without time zone'
       appearancepurpose: text
       appearancereason: text
       appearancepart: text
@@ -126,7 +126,7 @@ schema:
       amendedfromjudgmentsequence: int
       judgmenttype: text
       fileddate: date
-      entereddatetime: timestamp
+      entereddatetime: 'timestamp without time zone'
       withpossession: boolean
       latestjudgmentstatus: text
       latestjudgmentstatusdate: date

--- a/src/tests/integration/test_nycdb.py
+++ b/src/tests/integration/test_nycdb.py
@@ -434,6 +434,13 @@ def test_oca(conn):
         assert rec['fileddate'].strftime('%Y-%m-%d') == '2016-02-04'
         assert rec['specialtydesignationtypes'] == ['Specialty (HHP) Zipcodes']
         assert rec['primaryclaimtotal'] == Decimal('2740.46')
+    # make sure datatimes are working
+    test_id = '00000131D2D43B62D4764607D1AB017FC536618A72F3795716341A8DD100CBEF'
+    with conn.cursor(cursor_factory=psycopg2.extras.DictCursor) as curs:
+        curs.execute("select * from oca_appearances WHERE indexnumberid = '{}'".format(test_id))
+        rec = curs.fetchone()
+        assert rec is not None
+        assert rec['appearancedatetime'].strftime('%Y-%m-%d %I:%M:%S') == '2016-05-11 09:30:00'
 
 
 def run_cli(args, input):


### PR DESCRIPTION
After initially adding creating the OCA PR (#129) I noticed that timestamps weren't being parsed correctly. I then added that functionality to nycdb (#129). 

But I didn't have a chance to clean up the formatting of the data type in the yaml (`'timestamp without time zone'`) and add an extra test for timestamps. This PR adds these two things. 