### PR TITLE
change all bin to char(7)

### DIFF
--- a/src/ADDING_NEW_DATASETS.md
+++ b/src/ADDING_NEW_DATASETS.md
@@ -97,7 +97,7 @@ schema:
     EcbViolationNumber: text
     EcbViolationStatus: text
     DobViolationNumber: text
-    bin: text
+    bin: char(7)
     boro: char(1)
     block: char(5)
     lot: char(4)

--- a/src/nycdb/datasets/dob_complaints.yml
+++ b/src/nycdb/datasets/dob_complaints.yml
@@ -12,7 +12,7 @@ schema:
     housenumber: text
     zipcode: text
     housestreet: text
-    bin: integer
+    bin: char(7)
     communityboard: integer
     specialdistrict: text
     complaintcategory: text

--- a/src/nycdb/datasets/dob_violations.yml
+++ b/src/nycdb/datasets/dob_violations.yml
@@ -9,7 +9,7 @@ schema:
     BBL: char(10)
     IsnDobBisViol: text
     boro: char(1)
-    Bin: text
+    Bin: char(7)
     block: text
     lot: text
     IssueDate: date

--- a/src/nycdb/datasets/dobjobs.yml
+++ b/src/nycdb/datasets/dobjobs.yml
@@ -18,7 +18,7 @@ schema:
     StreetName: text
     Block: text
     Lot: text
-    Bin: integer
+    Bin: char(7)
     JobType: text
     JobStatus: text
     JobStatusDescrp: text
@@ -106,6 +106,6 @@ schema:
     GISCOUNCILDISTRICT: smallint
     GISCENSUSTRACT: text
     GISNTANAME: text
-    GISBIN: integer
+    GISBIN: char(7)
     bbl: char(10)
     id: 'serial PRIMARY KEY'

--- a/src/nycdb/datasets/ecb_violations.yml
+++ b/src/nycdb/datasets/ecb_violations.yml
@@ -12,7 +12,7 @@ schema:
     EcbViolationNumber: text
     EcbViolationStatus: text
     DobViolationNumber: text
-    bin: text
+    bin: char(7)
     boro: char(1)
     block: char(5)
     lot: char(4)

--- a/src/nycdb/datasets/hpd_registrations.yml
+++ b/src/nycdb/datasets/hpd_registrations.yml
@@ -34,7 +34,7 @@ schema:
       zip: text
       block: smallint
       lot: smallint
-      BIN: integer
+      BIN: char(7)
       communityboard: smallint
       lastregistrationdate: date
       registrationenddate: date

--- a/src/nycdb/datasets/hpd_violations.yml
+++ b/src/nycdb/datasets/hpd_violations.yml
@@ -45,6 +45,6 @@ schema:
     CommunityBoard: text
     CouncilDistrict: smallint
     CensusTract: text
-    BIN: integer
+    BIN: char(7)
     BBL: char(10)
     NTA: text


### PR DESCRIPTION
As noted in #139, the BIN (building identification number) does have a consistent type across all the datasets (sometimes text, int, etc.) and so I proposed that we change them all to `char(7)` like we've done for BBL `char(10)`. 

This PR makes all the changes in the yml files. 

I'm not sure if this will cause a problem with any downstream projects though. I took a look at wow and the `wow_bldgs` table has bin as an integer, but there may be other places that this is a problem. 

It's not the big a deal to just cast it where needed, but it seems like it might be worth making the switch if it does create a lot of work for people on other projects.