### PR TITLE
Fix pyproj deprecated call

### DIFF
--- a/src/nycdb/geo.py
+++ b/src/nycdb/geo.py
@@ -1,7 +1,7 @@
 import pyproj
 
 ny_state_plane = pyproj.Proj("epsg:2263", preserve_units=True)
-wgs84 = pyproj.Proj(init="epsg:4326")
+wgs84 = pyproj.Proj("epsg:4326")
 transformer = pyproj.Transformer.from_proj(ny_state_plane, wgs84)
 
 def ny_state_coords_to_lat_lng(xcoord, ycoord):

--- a/src/nycdb/transform.py
+++ b/src/nycdb/transform.py
@@ -112,7 +112,7 @@ def with_geo(table):
     for row in table:
         try:
             coords = (float(row['xcoord']), float(row['ycoord']))
-            lng, lat = ny_state_coords_to_lat_lng(*coords)
+            lat, lng = ny_state_coords_to_lat_lng(*coords)
             yield merge(row, {'lng': lng, 'lat': lat})
         except:
             yield merge(row, {'lng': None, 'lat': None})

--- a/src/tests/unit/test_geo.py
+++ b/src/tests/unit/test_geo.py
@@ -3,5 +3,5 @@ import nycdb
 def test_ny_state_coords_to_lat_lng():
     coords = [987838, 195989]
     result = nycdb.geo.ny_state_coords_to_lat_lng(*coords)
-    expected = [-73.98706, 40.70462]
+    expected = [40.70462, -73.98706]
     assert list(map(lambda x: round(x, 5), result)) == expected


### PR DESCRIPTION
When using the cli command I have been receiving the following deprecation warning:

```
 /usr/local/lib/python3.7/site-packages/pyproj/crs/crs.py:53: FutureWarning: '+init=<authority>:<code>' syntax is deprecated. '<authority>:<code>' is the preferred initialization method. When making the change, be mindful of axis order changes: https://pyproj4.github.io/pyproj/stable/gotchas.html#axis-order-changes-in-proj-6
```

It seems to be coming from src/nydb/geo.py:
```
wgs84 = pyproj.Proj(init="epsg:4326")
```

If I remove the 'init=', it seems to flip the order in which it returns latitude and longitude. I made the subsequent change in transform.py and fixed the one test that was referring to this call, and all the tests are passing. 

With this change and the subsequent change to flip the order of lat, lng, the deprecation warning goes away.