### PR TITLE
Allow hyphens and internal spaces back in to house numbers

### DIFF
--- a/src/nycdb/address.py
+++ b/src/nycdb/address.py
@@ -130,11 +130,10 @@ def normalize_street(street):
     return func_chain(STREET_FUNCS, s).replace('.', '').strip()
 
 
-# remove dashes or spaces...sorry Queens!
 def normalize_street_number(number):
     if number is None or number == '':
         return None
-    return re.sub(r'(?<=\d)(-|[ ])(?=\d)', '', number).replace('-', '').strip()
+    return number.strip()
 
 
 APT_STRINGS_TO_REMOVE = ['.', '_', '#', '{', '}', '/']

--- a/src/tests/unit/test_address.py
+++ b/src/tests/unit/test_address.py
@@ -65,9 +65,12 @@ class TestNormalizeStreet(object):
 
 
 def test_normalize_street_number():
+    assert normalize_street_number(None) is None
+    assert normalize_street_number('') is None
     assert normalize_street_number('24') == '24'
-    assert normalize_street_number('101-23') == '10123'
-    assert normalize_street_number('30-80') == '3080'
+    assert normalize_street_number('101-23') == '101-23'
+    assert normalize_street_number('30 80') == '30 80'
+    assert normalize_street_number(' 301  ') == '301'
 
 
 def test_normalize_apartment_returns_nil():


### PR DESCRIPTION
So, we received a comment from an organizer at Flatbush Tenant Coalition that some tools that relied on nycdb were removing dashes from house numbers for building in Queens, and given that they were trying to send physical mail to the address, were worried about the deliverability. This PR takes out a step in the address cleaning script that removed hyphens and internal spaces from house numbers in the `hpd_contacts` and `hpd_registrations` tables.

To get a sense of the effects of this change, you can check out [these tables](https://docs.google.com/spreadsheets/d/17ZJgul_j7E_gfkuurhIX0lJWA3e0fn1MGzyUKdRYxRU/edit?usp=sharing), which show all house numbers with dashes or internal spaces that show up in these two datasets, as well as the frequency at which they occur. From my analysis, the VAST majority of these house numbers validly have the space or dash in them. 