### PR TITLE
Add an index on bbl to the hpd_complaints table

### DIFF
--- a/src/nycdb/sql/hpd_complaints.sql
+++ b/src/nycdb/sql/hpd_complaints.sql
@@ -1,3 +1,4 @@
 CREATE INDEX hpd_complaints_buildingid_idx on hpd_complaints (buildingid);
 CREATE INDEX hpd_complaints_complaintid_idx on hpd_complaints (complaintid);
 CREATE INDEX hpd_complaint_problems_complaintid_idx on hpd_complaint_problems (complaintid);
+CREATE INDEX hpd_complaints_bbl_idx on hpd_complaints (bbl);


### PR DESCRIPTION
This is intended to speed up the Data Driven Optimization (DDO) query on the Justfix tenant platform, but it may be helpful for other queries as well.

