### PR TITLE
Add reference to SQL code in hpd_vacateorders.yml

### DIFF
--- a/src/nycdb/datasets/hpd_vacateorders.yml
+++ b/src/nycdb/datasets/hpd_vacateorders.yml
@@ -3,6 +3,8 @@ files:
   -
     url: https://data.cityofnewyork.us/api/views/tb8q-a3ar/rows.csv?accessType=DOWNLOAD
     dest: hpd_vacateorders.csv
+sql:
+  - hpd_vacateorders.sql
 schema:
   table_name: hpd_vacateorders
   fields:


### PR DESCRIPTION
This PR fixes a bug where the table indexes defined in [hpd_vacateorders.sql](https://github.com/nycdb/nycdb/blob/main/src/nycdb/sql/hpd_vacateorders.sql) were not running when loading the `hpd_vacateorders` table because they were not referenced in the table's .yml file.