### PR TITLE
Convert hpd_registrations `block` field from smallint to int

### DIFF
--- a/src/nycdb/datasets/hpd_registrations.yml
+++ b/src/nycdb/datasets/hpd_registrations.yml
@@ -32,7 +32,7 @@ schema:
       streetname: text
       streetcode: integer
       zip: text
-      block: smallint
+      block: integer
       lot: smallint
       BIN: char(7)
       communityboard: smallint


### PR DESCRIPTION
So, turns out 549 Ellsworth Ave in the Bronx is on block `55487`. Since our yml for the `hpd_registrations` dataset types the block field as smallint, we started getting a "smallint out of range" error since this block value was larger than the smallint upper bound of 32,767. This PR just converts this field type to the next largest int size `integer`.