### PR TITLE
don't add computed lat/lng for pluto

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 ARG PYTHON_VERSION=latest
 FROM python:${PYTHON_VERSION}
 
-RUN apt-get update && apt-get install -y postgresql-client libpq-dev proj-bin libproj-dev
+RUN apt-get update && apt-get install -y postgresql-client libpq-dev
 WORKDIR /nycdb/src
 COPY ./src/ /nycdb/src/
 RUN pip install pytest

--- a/src/nycdb/__init__.py
+++ b/src/nycdb/__init__.py
@@ -1,14 +1,9 @@
 """nycdb - nyc housing database"""
 
-__version__ = '0.1.0'
-__author__ = 'ziggy <ziggy@elephant-bird.net>'
 #__all__ = []
 
-from . import typecast, sql, transform, bbl, address, geo
+from . import typecast, sql, transform, bbl, address
 from .database import Database
 from .dataset import Dataset
 from .datasets import datasets
 from .file import File
-
-
-#datasets = _datasets()

--- a/src/nycdb/dataset_transformations.py
+++ b/src/nycdb/dataset_transformations.py
@@ -4,7 +4,7 @@ Each function in this file is the name of a table or dataset.
 import logging
 
 
-from .transform import with_geo, with_bbl, to_csv, stream_files_from_zip, extract_csv_from_zip, skip_fields
+from .transform import with_bbl, to_csv, stream_files_from_zip, extract_csv_from_zip, skip_fields
 from .transform import hpd_registrations_address_cleanup, hpd_contacts_address_cleanup
 from .datasets import datasets
 
@@ -32,11 +32,7 @@ def _pluto(dataset):
     """
     extension = 'txt' if dataset.name == 'pluto_10v1' else 'csv'
 
-    pluto_generator = with_geo(
-        to_csv(
-            stream_files_from_zip(dataset.files[0].dest, extension=extension)
-        )
-    )
+    pluto_generator = to_csv(stream_files_from_zip(dataset.files[0].dest, extension=extension))
 
     pluto_fields_to_skip = dataset.schemas[0].get('skip')
 

--- a/src/nycdb/datasets/pluto_10v1.yml
+++ b/src/nycdb/datasets/pluto_10v1.yml
@@ -88,8 +88,6 @@ schema:
     APPDate: date
     PLUTOMapID: char(1)
     Version: text
-    lng: 'double precision'
-    lat: 'double precision'
   skip:
     - RPADDate
     - DCASDate

--- a/src/nycdb/datasets/pluto_15v1.yml
+++ b/src/nycdb/datasets/pluto_15v1.yml
@@ -91,6 +91,3 @@ schema:
     APPDate: date
     PLUTOMapID: char(1)
     Version: text
-    lng: 'double precision'
-    lat: 'double precision'
-    

--- a/src/nycdb/datasets/pluto_16v2.yml
+++ b/src/nycdb/datasets/pluto_16v2.yml
@@ -90,6 +90,3 @@ schema:
     APPDate: date
     PLUTOMapID: char(1)
     Version: text
-    lng: 'double precision'
-    lat: 'double precision'
-    

--- a/src/nycdb/datasets/pluto_17v1.yml
+++ b/src/nycdb/datasets/pluto_17v1.yml
@@ -93,6 +93,3 @@ schema:
     Firm07Flag: char(1)
     pfirm15flag: char(1)
     Version: text
-    lng: 'double precision'
-    lat: 'double precision'
-    

--- a/src/nycdb/datasets/pluto_18v1.yml
+++ b/src/nycdb/datasets/pluto_18v1.yml
@@ -93,7 +93,3 @@ schema:
     Firm07Flag: char(1)
     pfirm15flag: char(1)
     Version: text
-    lng: 'double precision'
-    lat: 'double precision'
-    
-

--- a/src/nycdb/datasets/pluto_18v2.yml
+++ b/src/nycdb/datasets/pluto_18v2.yml
@@ -96,8 +96,6 @@ schema:
     Firm07Flag: char(1)
     pfirm15flag: char(1)
     geom: text
-    lng: 'double precision'
-    lat: 'double precision'
   skip:
     - mapplutof
     - rpaddate
@@ -108,4 +106,3 @@ schema:
     - masdate
     - polidate
     - edesigdate
-

--- a/src/nycdb/datasets/pluto_19v1.yml
+++ b/src/nycdb/datasets/pluto_19v1.yml
@@ -95,8 +95,6 @@ schema:
     Firm07Flag: char(1)
     pfirm15flag: char(1)
     geom: text
-    lng: 'double precision'
-    lat: 'double precision'
   skip:
     - mapplutof
     - rpaddate

--- a/src/nycdb/datasets/pluto_19v2.yml
+++ b/src/nycdb/datasets/pluto_19v2.yml
@@ -96,8 +96,6 @@ schema:
     pfirm15flag: char(1)
     geom: text
     dcpedited: text
-    lng: 'double precision'
-    lat: 'double precision'
   skip:
     - mapplutof
     - rpaddate

--- a/src/nycdb/datasets/pluto_20v8.yml
+++ b/src/nycdb/datasets/pluto_20v8.yml
@@ -109,5 +109,3 @@ schema:
     - masdate
     - polidate
     - edesigdate
-    - lng
-    - lat

--- a/src/nycdb/datasets/pluto_21v3.yml
+++ b/src/nycdb/datasets/pluto_21v3.yml
@@ -109,5 +109,3 @@ schema:
     - masdate
     - polidate
     - edesigdate
-    - lng
-    - lat

--- a/src/nycdb/geo.py
+++ b/src/nycdb/geo.py
@@ -1,8 +1,0 @@
-import pyproj
-
-ny_state_plane = pyproj.Proj("epsg:2263", preserve_units=True)
-wgs84 = pyproj.Proj("epsg:4326")
-transformer = pyproj.Transformer.from_proj(ny_state_plane, wgs84)
-
-def ny_state_coords_to_lat_lng(xcoord, ycoord):
-    return transformer.transform(xcoord, ycoord)

--- a/src/nycdb/transform.py
+++ b/src/nycdb/transform.py
@@ -7,7 +7,6 @@ from zipfile import ZipFile
 from .address import normalize_street, normalize_street_number, normalize_apartment
 from .bbl import bbl
 from .utility import merge
-from .geo import ny_state_coords_to_lat_lng
 
 invalid_header_chars = ["\n", "\r", ' ', '-', '#', '.', "'", '"', '_', '/', '(', ')', ':']
 replace_header_chars = [('%', 'pct')]
@@ -113,16 +112,6 @@ def to_csv(file_path_or_generator):
 def with_bbl(table, borough='borough', block='block', lot='lot'):
     for row in table:
         yield merge(row, {'bbl': bbl(row[borough], row[block], row[lot])})
-
-
-def with_geo(table):
-    for row in table:
-        try:
-            coords = (float(row['xcoord']), float(row['ycoord']))
-            lat, lng = ny_state_coords_to_lat_lng(*coords)
-            yield merge(row, {'lng': lng, 'lat': lat})
-        except:
-            yield merge(row, {'lng': None, 'lat': None})
 
 
 def skip_fields(table, fields_to_skip):

--- a/src/setup.py
+++ b/src/setup.py
@@ -34,7 +34,6 @@ setuptools.setup(
     install_requires=[
         'PyYAML>=5.1',
         'requests>=2.18',
-        'pyproj>=2.1.3',
         'psycopg2>=2.7',
         'tqdm>=4.28.1'
     ],

--- a/src/tests/integration/test_nycdb.py
+++ b/src/tests/integration/test_nycdb.py
@@ -173,8 +173,6 @@ def test_pluto_insert(conn):
         assert rec is not None
         assert rec['address'] == '369 PARK AVENUE SOUTH'
         assert rec['lotarea'] == 8032
-        assert round(rec['lng'], 5) == -73.98434
-        assert round(rec['lat'], 5) == 40.74211
 
 
 def test_pluto17v1(conn):

--- a/src/tests/unit/test_geo.py
+++ b/src/tests/unit/test_geo.py
@@ -1,7 +1,0 @@
-import nycdb
-
-def test_ny_state_coords_to_lat_lng():
-    coords = [987838, 195989]
-    result = nycdb.geo.ny_state_coords_to_lat_lng(*coords)
-    expected = [40.70462, -73.98706]
-    assert list(map(lambda x: round(x, 5), result)) == expected


### PR DESCRIPTION
`nycdb` was using pyproj to convert coordinates in the pluto dataset from ny state coordinate system to the more familiar latitude and longitude. The latest versions of pluto now includes those fields, making this unnecessary. 