### PR TITLE
typecast functions return None input, add tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,5 @@ modules/hpd-complaints/*.csv
 src/.pytest_cache/
 
 *.bz2
+
+.vscode

--- a/.gitignore
+++ b/.gitignore
@@ -25,5 +25,3 @@ modules/hpd-complaints/*.csv
 src/.pytest_cache/
 
 *.bz2
-
-.vscode

--- a/src/nycdb/typecast.py
+++ b/src/nycdb/typecast.py
@@ -92,6 +92,9 @@ def mm_dd_yyyy(date_str):
 # TODO: allow for different date inputs besides mm/dd/yyyy
 #  03/04/2015 12:00:00 AM
 def date(x):
+    if x is None:
+        return None
+        
     if isinstance(x, (datetime.date, datetime.datetime)):
         return x
     # checks for 2018-12-31 date input
@@ -138,6 +141,9 @@ def timestamp(x):
     Converts string into datetime.datetime
     Example inputs: '2020-12-31 13:01:01', '2020-12-31 01:01:01 PM'
     """
+    if x is None:
+        return None
+        
     if isinstance(x, datetime.datetime):
         return x
     x_parts = x.strip().split(' ', 1)
@@ -160,6 +166,8 @@ def boolean(x):
 
 
 def text_array(x, sep=","):
+    if x is None:
+        return None
     return x.strip().split(sep)
 
 

--- a/src/tests/unit/test_typecast.py
+++ b/src/tests/unit/test_typecast.py
@@ -12,6 +12,7 @@ def test_integer():
     assert typecast.integer('10') == 10
     assert typecast.integer('  10  ') == 10
     assert typecast.integer('') is None
+    assert typecast.integer(None) is None
     assert typecast.integer('NOT AN INTEGER') is None
 
 
@@ -32,6 +33,7 @@ def test_char():
     assert typecast.char('test', 2) == 'te'
     assert typecast.char(' test', 2) == 'te'
     assert typecast.char(345, 3) == '345'
+    assert typecast.char(None, 3) is None
 
 
 def test_boolean():
@@ -40,17 +42,20 @@ def test_boolean():
     assert typecast.boolean('X') is True
     assert typecast.boolean('no') is False
     assert typecast.boolean('am i true or false?') is None
+    assert typecast.boolean(None) is None
 
 
 def test_numeric():
     assert typecast.numeric('1.5') == Decimal('1.5')
     assert typecast.numeric('') is None
+    assert typecast.numeric(None) is None
 
 
 def test_to_float():
     assert typecast.to_float(12.5) == 12.5
     assert typecast.to_float('12.5') == 12.5
     assert typecast.to_float('not a number') is None
+    assert typecast.to_float(None) is None
 
 
 def test_date_yyyymmdd_string():
@@ -84,6 +89,9 @@ def test_date_bad_str():
     assert typecast.date('01/01/0000') is None
     assert typecast.date('WHATHAPP') is None
 
+def test_date_none():
+    assert typecast.date(None) is None
+
 
 def test_date_mm_dd_yyyy_with_timestamp():
     assert typecast.date('03/04/2015 12:00:00 AM') == datetime.date(2015, 3, 4)
@@ -96,6 +104,7 @@ def test_time():
     assert typecast.time('3:01:00 AM') == datetime.time(hour=3, minute=1, second=0)
     assert typecast.time(datetime.time.min) == datetime.time.min
     assert typecast.time('RIGHT NOW') is None
+    assert typecast.time(None) is None
 
 
 def test_timestamp():
@@ -111,10 +120,13 @@ def test_timestamp_bad_str():
     assert typecast.timestamp('05/13/2020 23:30:00 AM XYZ') == None
     assert typecast.timestamp('WHATHAPP') == None
 
+def test_timestamp_none():
+    assert typecast.timestamp(None) is None
 
 def test_text_array():
     assert typecast.text_array('  one,two,three  ') == ['one', 'two', 'three']
     assert typecast.text_array('1|2|3', sep='|') == ['1', '2', '3']
+    assert typecast.text_array(None) is None
 
 
 def test_typecast_init():


### PR DESCRIPTION
Recently ACRIS updates have been failing because there are rows where the date fields are `None` when the typecasts are attempted, and those functions are expecting strings and fail on the regex match steps. 

This PR adds some simple checks for those typecast functions (`if None: return None`), and adds these `None` input cases to the unit tests. All the tests are passing and I was able to load ACRIS locally without problems. 

Error log:
<details>

```
OrderedDict([('documentid', '2014061900679001'), ('recordtype', 'A'), ('crfn', '20140002927{'), ('borough', None), ('doctype', None), ('docdate', None), ('docamount', None), ('recordedfiled', None), ('modifieddate', None), ('reelyear', None), ('reelnbr', None), ('reelpage', None), ('pcttransferred', None), ('goodthroughdate', None)])
Destroying temporary schema 'temp_acris_1647986606'.
Alas, an error occurred when loading the dataset `acris`.
Traceback (most recent call last):
File "load_dataset.py", line 353, in <module>
main()
File "load_dataset.py", line 349, in main
load_dataset(dataset)
File "load_dataset.py", line 287, in load_dataset
ds.db_import()
File "/nycdb/src/nycdb/dataset.py", line 73, in db_import
self.import_schema(schema)
File "/nycdb/src/nycdb/dataset.py", line 119, in import_schema
batch = list(itertools.islice(rows, 0, BATCH_SIZE))
File "/nycdb/src/nycdb/typecast.py", line 183, in cast_rows
yield self.cast_row(row)
File "/nycdb/src/nycdb/typecast.py", line 194, in cast_row
d[column] = self.cast[column.lower()](val)
File "/nycdb/src/nycdb/typecast.py", line 221, in <lambda>
d[k] = lambda x: date(x)
File "/nycdb/src/nycdb/typecast.py", line 95, in date
if re.match(r'\d{4}-\d{1,2}-\d{1,2}', x):
File "/usr/local/lib/python3.6/re.py", line 172, in match
return _compile(pattern, flags).match(string)
TypeError: expected string or bytes-like object
Logs from Mar 22, 2022 to Mar 22, 2022 UTC
```
</details>