### PR TITLE
use raw strings for regex to fix deprecation warnings 

### DIFF
--- a/src/nycdb/annual_sales.py
+++ b/src/nycdb/annual_sales.py
@@ -32,7 +32,7 @@ headers = [
 class AnnualSales:
     def __init__(self, filename):
         self.filename = filename
-        self.year = re.search("\d{4}", basename(self.filename)).group()
+        self.year = re.search(r"\d{4}", basename(self.filename)).group()
         self.ext = splitext(self.filename)[1]
 
     def __iter__(self):

--- a/src/nycdb/dof_421a.py
+++ b/src/nycdb/dof_421a.py
@@ -14,7 +14,7 @@ def validate_header_row(row):
 
 
 def iter_421a(filename):
-    fiscalyear = re.search("_(\d{4})_", os.path.basename(filename)).group(1)
+    fiscalyear = re.search(r"_(\d{4})_", os.path.basename(filename)).group(1)
     workbook = openpyxl.load_workbook(filename)
     worksheet = workbook[workbook.sheetnames[0]]
     rows = worksheet.iter_rows(values_only=True)


### PR DESCRIPTION
There were a couple of regex patterns that raised these warnings: ```DeprecationWarning: invalid escape sequence '\d'```
This PR just makes those patterns use raw text strings to solve this. 