### PR TITLE
change healthcheck test to fix root user error

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,7 +31,7 @@ services:
     ports:
       - 127.0.0.1:5432:5432
     healthcheck:
-      test: pg_isready
+      test: [ "CMD-SHELL", "pg_isready -d $${POSTGRES_DB} -U $${POSTGRES_USER}" ]
       timeout: 5s
       interval: 1s
       retries: 20


### PR DESCRIPTION
When running `docker-compose up` it was raising this error: `FATAL:  role "root" does not exist`
It seems to be an issue with the healtcheck test `pg_isready` using the wrong user by default. 

This PR changes the test to specify the correct `nycdb` user. 
