### PR TITLE
Feat. add landuse description rollup

### DIFF
--- a/src/nycdb/sql/pluto_latest.sql
+++ b/src/nycdb/sql/pluto_latest.sql
@@ -3,7 +3,7 @@ ALTER TABLE pluto_latest RENAME COLUMN communityboard TO cd;
 ALTER TABLE pluto_latest RENAME COLUMN censustract2010 TO ct2010;
 ALTER TABLE pluto_latest RENAME COLUMN councildistrict TO council;
 ALTER TABLE pluto_latest RENAME COLUMN postcode TO zipcode;
-ALTER TABLE pluto_latest ADD COLUMN landusdesc text;
+ALTER TABLE pluto_latest ADD COLUMN landusedesc text;
 UPDATE pluto_latest SET landusedesc = CASE
     	WHEN landuse = 1 THEN 'One & Two Family Buildings'
     	WHEN landuse = 2 THEN 'Multi-Family Walk-Up Buildings'

--- a/src/nycdb/sql/pluto_latest.sql
+++ b/src/nycdb/sql/pluto_latest.sql
@@ -3,5 +3,20 @@ ALTER TABLE pluto_latest RENAME COLUMN communityboard TO cd;
 ALTER TABLE pluto_latest RENAME COLUMN censustract2010 TO ct2010;
 ALTER TABLE pluto_latest RENAME COLUMN councildistrict TO council;
 ALTER TABLE pluto_latest RENAME COLUMN postcode TO zipcode;
-
+ALTER TABLE pluto_latest ADD COLUMN landusdesc text;
+UPDATE pluto_latest SET landusedesc = CASE
+    	WHEN landuse = 1 THEN 'One & Two Family Buildings'
+    	WHEN landuse = 2 THEN 'Multi-Family Walk-Up Buildings'
+    	WHEN landuse = 3 THEN 'Multi-Family Elevator Buildings'
+      WHEN landuse = 4 THEN 'Mixed Residential & Commercial Buildings'
+      WHEN landuse = 5 THEN 'Commercial & Office Buildings'
+      WHEN landuse = 6 THEN 'Industrial & Manufacturing'
+      WHEN landuse = 7 THEN 'Transportation & Utility'
+      WHEN landuse = 8 THEN 'Public Facilities & Institutions'
+      WHEN landuse = 9 THEN 'Open Space & Outdoor Recreation'
+      WHEN landuse = 10 THEN 'Parking Facilities'
+      WHEN landuse = 11 THEN 'Vacant Land'
+      WHEN landuse IS NULL THEN NULL
+      ELSE '9999'
+      END;
 CREATE INDEX pluto_latest_bbl_idx on pluto_latest (bbl);

--- a/src/tests/integration/test_nycdb.py
+++ b/src/tests/integration/test_nycdb.py
@@ -236,6 +236,13 @@ def test_pluto_latest(conn):
     pluto.db_import()
     assert row_count(conn, 'pluto_latest') == 5
 
+def test_pluto_sql_columns(conn):
+    with conn.cursor(cursor_factory=psycopg2.extras.DictCursor) as curs:
+        curs.execute("select * from pluto_latest WHERE landuse = 1")
+        rec = curs.fetchone()
+        assert rec['landusedesc'] == "One & Two Family Buildings"
+
+
 def test_hpd_violations(conn):
     drop_table(conn, 'hpd_violations')
     hpd_violations = nycdb.Dataset('hpd_violations', args=ARGS)


### PR DESCRIPTION
- Adds text description of land use code
- Sets description to null if code is null
- Sets description to '9999' if code is not null but not a number between 1 and 10 (the codes included in the documentation)

Thanks for the collab @pspauster :) 

Based on PLUTO [documentation](https://data.cityofnewyork.us/api/views/64uk-42ks/files/0bef0427-36f5-4d8d-867a-84dfa2477b9c?download=true&filename=PLUTODD.pdf) (page 20):

<img width="658" alt="image" src="https://user-images.githubusercontent.com/13337090/206868125-150d5efc-8d1f-48e6-ae96-f7ac78b90fed.png">