### PR TITLE
add dob vacate orders

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ Residents, lawyers, tenants, and organizers who want to use data in their strugg
 - [Department of City Planning's PLUTO](https://github.com/nycdb/nycdb/wiki/Dataset:-PLUTO) (Includes the [latest version via Open Data](https://data.cityofnewyork.us/City-Government/Primary-Land-Use-Tax-Lot-Output-PLUTO-/64uk-42ks), and many other specific versions. See documentatino for details)
 - [DOB Job Filings](https://github.com/nycdb/nycdb/wiki/Dataset:-DOB-Job-Filings)
 - [DOB Complaints](https://github.com/nycdb/nycdb/wiki/Dataset:-DOB-Complaints)
+- [DOB Vacate Orders](https://github.com/nycdb/nycdb/wiki/Dataset:-DOB-Vacate-Orders) - From [FOIA request by Jennah Gosciak](https://github.com/jennahgosciak/dob_vacate_orders)
 - [DOB Violations](https://github.com/nycdb/nycdb/wiki/Dataset:-DOB-Violations)
 - [HPD Violations](https://github.com/nycdb/nycdb/wiki/Dataset:-HPD-Violations)
 - [HPD Litigations](https://github.com/nycdb/nycdb/wiki/Dataset:-HPD-Litigations)

--- a/src/nycdb/dataset_transformations.py
+++ b/src/nycdb/dataset_transformations.py
@@ -191,3 +191,7 @@ def hpd_conh(dataset):
 
 def dcp_housingdb(dataset):
     return to_csv(extract_csv_from_zip(dataset.files[0].dest, "HousingDB_post2010.csv"))
+
+
+def dob_vacate_orders(dataset):
+    return with_bbl(to_csv(dataset.files[0].dest), borough='boroughname')

--- a/src/nycdb/datasets/dob_vacate_orders.yml
+++ b/src/nycdb/datasets/dob_vacate_orders.yml
@@ -1,0 +1,21 @@
+---
+files:
+  -
+    url: https://raw.githubusercontent.com/jennahgosciak/dob_vacate_orders/main/Vacates_from_2012_v3.csv
+    dest: dob_vacate_orders.csv
+sql:
+  - dob_vacate_orders.sql
+schema:
+  table_name: dob_vacate_orders
+  fields:
+    LastDispositionDateDateOfIssuanceOfVacate: date
+    LastDispositionYear: integer
+    HouseNumber: text
+    StreetName: text
+    BoroughName: text
+    ZipCode: char(5)
+    Block: integer
+    Lot: integer
+    ComplaintCategoryDescription: text
+    LastDispositionCodeDescription: text
+    BBL: char(10)

--- a/src/nycdb/sql/dob_vacate_orders.sql
+++ b/src/nycdb/sql/dob_vacate_orders.sql
@@ -1,0 +1,3 @@
+ALTER TABLE dob_vacate_orders RENAME COLUMN LastDispositionDateDateOfIssuanceOfVacate to LastDispositionDate;
+CREATE INDEX dob_vacate_orders_bbl_idx on dob_vacate_orders (bbl);
+CREATE INDEX dob_vacate_orders_lastdispositiondate_idx on dob_vacate_orders (LastDispositionDate);

--- a/src/nycdb/typecast.py
+++ b/src/nycdb/typecast.py
@@ -109,8 +109,8 @@ def date(x):
             return datetime.datetime.strptime(x, '%Y%m%d').date()
         except ValueError:
             return None
-    # checks for 12/31/2018 date input
-    elif len(x) == 10 and len(x.split('/')) == 3:
+    # checks for 09/30/2018 and 9/2/2022 date inputs
+    elif re.match(r'^\d{1,2}/\d{1,2}/\d{4}$', x):
         return mm_dd_yyyy(x)
     # checks for 12/31/2018 12:00:00 AM date input
     elif len(x) == 22 and len(x[0:10].split('/')) == 3:
@@ -241,3 +241,5 @@ class Typecast():
             else:
                 d[k] = lambda x: x
         return d
+
+print(date('1/3/2012'))

--- a/src/tests/integration/data/dob_vacate_orders.csv
+++ b/src/tests/integration/data/dob_vacate_orders.csv
@@ -1,0 +1,101 @@
+Last Disposition Date (date of issuance of vacate),Last Disposition Year,House Number,Street Name,Borough Name,ZIP Code,Block,Lot,Complaint  Category Description,Last Disposition Code Description
+1/3/2012,2012,62-66,83 STREET,Queens,11379,2970,38,ILLEGAL CONVERSION                                                        +,PARTIAL VACATE ORDER ISSUED                                              P
+1/3/2012,2012,203-02,104 AVENUE,Queens,11412,10903,1,ILLEGAL CONVERSION                                                        +,PARTIAL VACATE ORDER ISSUED                                              P
+1/4/2012,2012,58-41,PENROD STREET,Queens,11368,1959,33,ILLEGAL CONVERSION                                                        +,PARTIAL VACATE ORDER ISSUED                                              P
+1/4/2012,2012,77-02,PITKIN AVENUE,Queens,11417,9136,156,ILLEGAL CONVERSION                                                        +,PARTIAL VACATE ORDER ISSUED                                              P
+1/6/2012,2012,2391,FOREST AVENUE,Staten Island,10303,1290,9,BUILDING SHAKING/VIBRATING/STRUCT STABILITY AFFECTED,PARTIAL VACATE ORDER ISSUED                                              P
+1/7/2012,2012,3321,SEYMOUR AVENUE,Bronx,10469,4736,27,ILLEGAL CONVERSION                                                        +,FULL VACATE ORDER ISSUED                                                 F
+1/9/2012,2012,290,EAST  151 STREET,Bronx,10451,2410,20,CERTIFICATE OF OCCUPANCY - NONE/ILLEGAL/CONTRARY TO CO,PARTIAL VACATE ORDER ISSUED                                              P
+1/10/2012,2012,1373,TELLER AVENUE,Bronx,10456,2782,41,ILLEGAL CONVERSION                                                        +,PARTIAL VACATE ORDER ISSUED                                              P
+1/10/2012,2012,118-48,226 STREET,Queens,11411,12762,90,ILLEGAL CONVERSION                                                        +,PARTIAL VACATE ORDER ISSUED                                              P
+1/11/2012,2012,3061,HEATH AVENUE,Bronx,10463,3261,69,ILLEGAL CONVERSION                                                        +,PARTIAL VACATE ORDER ISSUED                                              P
+1/12/2012,2012,80-55,  88 ROAD,Queens,11421,8916,54,ILLEGAL CONVERSION                                                        +,PARTIAL VACATE ORDER ISSUED                                              P
+1/12/2012,2012,114-41,143 STREET,Queens,11436,11973,25,ILLEGAL CONVERSION                                                        +,PARTIAL VACATE ORDER ISSUED                                              P
+1/12/2012,2012,69-10, 140 STREET,Queens,11367,6485,3,ILLEGAL CONVERSION                                                        +,PARTIAL VACATE ORDER ISSUED                                              P
+1/12/2012,2012,141-49,  84 DRIVE,Queens,11435,9713,144,ILLEGAL CONVERSION                                                        +,PARTIAL VACATE ORDER ISSUED                                              P
+1/12/2012,2012,175-11,  89 AVENUE,Queens,11432,9833,166,ILLEGAL CONVERSION                                                        +,PARTIAL VACATE ORDER ISSUED                                              P
+1/13/2012,2012,214,WEST 30 STREET,Manhattan,10001,779,52,CERTIFICATE OF OCCUPANCY - NONE/ILLEGAL/CONTRARY TO CO,PARTIAL VACATE ORDER ISSUED                                              P
+1/13/2012,2012,103-29, 116 STREET,Queens,11419,9554,42,ILLEGAL CONVERSION                                                        +,PARTIAL VACATE ORDER ISSUED                                              P
+1/14/2012,2012,419,MEEKER AVENUE,Brooklyn,11222,2724,1,BUILDING SHAKING/VIBRATING/STRUCT STABILITY AFFECTED,FULL VACATE ORDER ISSUED                                                 F
+1/14/2012,2012,417,MEEKER AVENUE,Brooklyn,11222,2724,37,BUILDING SHAKING/VIBRATING/STRUCT STABILITY AFFECTED,FULL VACATE ORDER ISSUED                                                 F
+1/16/2012,2012,1066,DECATUR STREET,Brooklyn,11207,3433,20,BUILDING SHAKING/VIBRATING/STRUCT STABILITY AFFECTED,FULL VACATE ORDER ISSUED                                                 F
+1/18/2012,2012,94-37,212 STREET,Queens,11428,10601,44,EGRESS - LOCKED/BLOCKED/IMPROPER/NO SECONDARY MEANS,PARTIAL VACATE ORDER ISSUED                                              P
+1/19/2012,2012,3271,   3 AVENUE,Bronx,10456,2368,35,FAILURE TO MAINTAIN,FULL VACATE ORDER ISSUED                                                 F
+1/19/2012,2012,147,SCHENCK AVENUE,Brooklyn,11207,3949,10,ILLEGAL CONVERSION                                                        +,PARTIAL VACATE ORDER ISSUED                                              P
+1/20/2012,2012,901,EAST   98 STREET,Brooklyn,11236,8148,26,PERMIT - NONE (BUILDING/ PA/ DEMO ETC.),PARTIAL VACATE ORDER ISSUED                                              P
+1/23/2012,2012,40-33,GLEANE STREET,Queens,11373,1503,69,ILLEGAL CONVERSION                                                        +,PARTIAL VACATE ORDER ISSUED                                              P
+1/24/2012,2012,731,EAST 215 STREET,Bronx,10467,4663,82,ILLEGAL CONVERSION                                                        +,PARTIAL VACATE ORDER ISSUED                                              P
+1/24/2012,2012,204,PENNSYLVANIA AVENUE,Brooklyn,11207,3720,25,ILLEGAL CONVERSION                                                        +,PARTIAL VACATE ORDER ISSUED                                              P
+1/24/2012,2012,106-13,79 STREET,Queens,11417,9135,143,ILLEGAL CONVERSION                                                        +,PARTIAL VACATE ORDER ISSUED                                              P
+1/24/2012,2012,22-Oct,DICKENS STREET,Queens,11691,15717,16,ILLEGAL CONVERSION                                                        +,PARTIAL VACATE ORDER ISSUED                                              P
+1/25/2012,2012,145,MANHATTAN AVENUE,Brooklyn,11206,3051,16,PERMIT - NONE (BUILDING/ PA/ DEMO ETC.),PARTIAL VACATE ORDER ISSUED                                              P
+1/25/2012,2012,223-01,113 DRIVE,Queens,11429,11241,47,ILLEGAL CONVERSION                                                        +,PARTIAL VACATE ORDER ISSUED                                              P
+1/27/2012,2012,114-16,147 STREET,Queens,11436,11977,22,ILLEGAL CONVERSION                                                        +,PARTIAL VACATE ORDER ISSUED                                              P
+1/27/2012,2012,179-20,SELOVER ROAD,Queens,11434,12475,29,ILLEGAL CONVERSION                                                        +,PARTIAL VACATE ORDER ISSUED                                              P
+1/30/2012,2012,96-26,46 AVENUE,Queens,11368,1622,8,SRO - ILLEGAL WORK/NO PERMIT/CHANGE IN OCCUP-USE                          +,PARTIAL VACATE ORDER ISSUED                                              P
+1/31/2012,2012,20,COMMERCE STREET,Manhattan,10014,587,12,PLUMBING WORK - ILLEGAL/NO PERMIT(ALSO SPRINKLER/STANDPIPE),PARTIAL VACATE ORDER ISSUED                                              P
+1/31/2012,2012,103,UTICA AVENUE,Brooklyn,11213,1349,4,EGRESS - LOCKED/BLOCKED/IMPROPER/NO SECONDARY MEANS,PARTIAL VACATE ORDER ISSUED                                              P
+1/31/2012,2012,117-43,126 STREET,Queens,11420,11748,24,ILLEGAL CONVERSION                                                        +,PARTIAL VACATE ORDER ISSUED                                              P
+1/31/2012,2012,130-15,177 STREET,Queens,11434,12539,29,ILLEGAL CONVERSION                                                        +,PARTIAL VACATE ORDER ISSUED                                              P
+2/1/2012,2012,162-07,65 AVENUE,Queens,11365,6759,7,SRO - ILLEGAL WORK/NO PERMIT/CHANGE IN OCCUP-USE                          +,PARTIAL VACATE ORDER ISSUED                                              P
+2/1/2012,2012,124-26,109 AVENUE,Queens,11420,11605,10,ILLEGAL CONVERSION                                                        +,PARTIAL VACATE ORDER ISSUED                                              P
+2/1/2012,2012,40,PARK HILL LANE,Staten Island,10304,2869,114,ILLEGAL CONVERSION                                                        +,PARTIAL VACATE ORDER ISSUED                                              P
+2/2/2012,2012,96-26,46 AVENUE,Queens,11368,1622,8,CERTIFICATE OF OCCUPANCY - NONE/ILLEGAL/CONTRARY TO CO,PARTIAL VACATE ORDER ISSUED                                              P
+2/2/2012,2012,117-18,150 AVENUE,Queens,11420,11840,40,"BUILDING - VACANT, OPEN AND UNGUARDED",FULL VACATE ORDER ISSUED                                                 F
+2/2/2012,2012,226-02,FRANCIS LEWIS BOULEVARD,Queens,11411,12825,137,EGRESS - LOCKED/BLOCKED/IMPROPER/NO SECONDARY MEANS,PARTIAL VACATE ORDER ISSUED                                              P
+2/2/2012,2012,23-85,DICKENS STREET,Queens,11691,15756,5,EGRESS - LOCKED/BLOCKED/IMPROPER/NO SECONDARY MEANS,PARTIAL VACATE ORDER ISSUED                                              P
+2/2/2012,2012,226-01,MERRICK BOULEVARD,Queens,11413,12965,23,CERTIFICATE OF OCCUPANCY - NONE/ILLEGAL/CONTRARY TO CO,PARTIAL VACATE ORDER ISSUED                                              P
+2/6/2012,2012,84-41,246 STREET,Queens,11426,8600,47,ILLEGAL CONVERSION                                                        +,PARTIAL VACATE ORDER ISSUED                                              P
+2/7/2012,2012,231,EAST   37 STREET,Brooklyn,11203,4874,43,BUILDING SHAKING/VIBRATING/STRUCT STABILITY AFFECTED,FULL VACATE ORDER ISSUED                                                 F
+2/7/2012,2012,108-50,45 AVENUE,Queens,11368,2001,23,BUILDING SHAKING/VIBRATING/STRUCT STABILITY AFFECTED,FULL VACATE ORDER ISSUED                                                 F
+2/8/2012,2012,293,EASTERN PARKWAY,Brooklyn,11238,1181,67,ILLEGAL HOTEL ROOMS IN RESIDENTIAL BUILDINGS,FULL VACATE ORDER ISSUED                                                 F
+2/8/2012,2012,101-04,34 AVENUE,Queens,11368,1735,2,EGRESS - LOCKED/BLOCKED/IMPROPER/NO SECONDARY MEANS,PARTIAL VACATE ORDER ISSUED                                              P
+2/8/2012,2012,91-54,114 STREET,Queens,11418,9321,17,ILLEGAL CONVERSION                                                        +,PARTIAL VACATE ORDER ISSUED                                              P
+2/8/2012,2012,95-24,VAN WYCK EXPRESSWAY,Queens,11419,9482,24,ILLEGAL CONVERSION                                                        +,PARTIAL VACATE ORDER ISSUED                                              P
+2/9/2012,2012,46,BULWER PLACE,Brooklyn,11207,3890,415,ILLEGAL CONVERSION                                                        +,PARTIAL VACATE ORDER ISSUED                                              P
+2/9/2012,2012,109-28,174 STREET,Queens,11433,10265,132,ILLEGAL CONVERSION                                                        +,PARTIAL VACATE ORDER ISSUED                                              P
+2/10/2012,2012,1834,EAST 4 STREET,Brooklyn,11223,6660,30,BUILDING SHAKING/VIBRATING/STRUCT STABILITY AFFECTED,PARTIAL VACATE ORDER ISSUED                                              P
+2/10/2012,2012,81-46,BAXTER AVENUE,Queens,11373,1506,10,FAILURE TO MAINTAIN,PARTIAL VACATE ORDER ISSUED                                              P
+2/10/2012,2012,111-09,NORTHERN BOULEVARD,Queens,11368,1705,41,ILLEGAL CONVERSION                                                        +,PARTIAL VACATE ORDER ISSUED                                              P
+2/10/2012,2012,104-18,125 STREET,Queens,11419,9578,16,ILLEGAL CONVERSION                                                        +,PARTIAL VACATE ORDER ISSUED                                              P
+2/10/2012,2012,84-70, 164 STREET,Queens,11432,9786,26,ILLEGAL CONVERSION                                                        +,PARTIAL VACATE ORDER ISSUED                                              P
+2/11/2012,2012,467,BEACH   22 STREET,Queens,11691,15771,54,ILLEGAL CONVERSION                                                        +,PARTIAL VACATE ORDER ISSUED                                              P
+2/12/2012,2012,2062,DEAN STREET,Brooklyn,11233,1446,9,BUILDING SHAKING/VIBRATING/STRUCT STABILITY AFFECTED,PARTIAL VACATE ORDER ISSUED                                              P
+2/13/2012,2012,370,HIMROD STREET,Brooklyn,11237,3281,12,BUILDING SHAKING/VIBRATING/STRUCT STABILITY AFFECTED,PARTIAL VACATE ORDER ISSUED                                              P
+2/13/2012,2012,324,IRVING AVENUE,Brooklyn,11237,3335,33,ILLEGAL CONVERSION                                                        +,PARTIAL VACATE ORDER ISSUED                                              P
+2/13/2012,2012,969,EAST   45 STREET,Brooklyn,11203,4992,50,ILLEGAL CONVERSION                                                        +,PARTIAL VACATE ORDER ISSUED                                              P
+2/13/2012,2012,19-12,PUTNAM AVENUE,Queens,11385,3482,1,ILLEGAL CONVERSION                                                        +,PARTIAL VACATE ORDER ISSUED                                              P
+2/13/2012,2012,107-12, 131 STREET,Queens,11419,9610,6,ILLEGAL CONVERSION                                                        +,PARTIAL VACATE ORDER ISSUED                                              P
+2/14/2012,2012,1432,GREENE AVENUE,Brooklyn,11237,3301,14,ILLEGAL CONVERSION                                                        +,PARTIAL VACATE ORDER ISSUED                                              P
+2/15/2012,2012,21,EAST 2 STREET,Manhattan,10003,457,20,BUILDING SHAKING/VIBRATING/STRUCT STABILITY AFFECTED,PARTIAL VACATE ORDER ISSUED                                              P
+2/15/2012,2012,195-15, 119 AVENUE,Queens,11412,12616,29,ILLEGAL CONVERSION                                                        +,PARTIAL VACATE ORDER ISSUED                                              P
+2/15/2012,2012,118-48,226 STREET,Queens,11411,12762,90,ILLEGAL CONVERSION                                                        +,PARTIAL VACATE ORDER ISSUED                                              P
+2/15/2012,2012,227-12,141 AVENUE,Queens,11413,13191,294,ILLEGAL CONVERSION                                                        +,PARTIAL VACATE ORDER ISSUED                                              P
+2/16/2012,2012,86-81, 102 STREET,Queens,11418,9288,145,CERTIFICATE OF OCCUPANCY - NONE/ILLEGAL/CONTRARY TO CO,PARTIAL VACATE ORDER ISSUED                                              P
+2/16/2012,2012,86-81, 102 STREET,Queens,11418,9288,145,ILLEGAL CONVERSION                                                        +,PARTIAL VACATE ORDER ISSUED                                              P
+2/16/2012,2012,114-55,LEFFERTS BOULEVARD,Queens,11420,11646,35,ILLEGAL CONVERSION                                                        +,PARTIAL VACATE ORDER ISSUED                                              P
+2/16/2012,2012,144-46,183 STREET,Queens,11413,13324,76,ILLEGAL CONVERSION                                                        +,PARTIAL VACATE ORDER ISSUED                                              P
+2/16/2012,2012,18-32,CORNAGA AVENUE,Queens,11691,15560,45,FAILURE TO MAINTAIN,PARTIAL VACATE ORDER ISSUED                                              P
+2/17/2012,2012,24-24,GILLMORE STREET,Queens,11369,1644,13,ILLEGAL CONVERSION                                                        +,PARTIAL VACATE ORDER ISSUED                                              P
+2/17/2012,2012,145-26,LIBERTY AVENUE,Queens,11435,10046,9,CERTIFICATE OF OCCUPANCY - NONE/ILLEGAL/CONTRARY TO CO,PARTIAL VACATE ORDER ISSUED                                              P
+2/17/2012,2012,80-60,  57 STREET,Queens,11385,3729,13,ILLEGAL CONVERSION                                                        +,PARTIAL VACATE ORDER ISSUED                                              P
+2/21/2012,2012,1339,MORRIS AVENUE,Bronx,10456,2816,53,FAILURE TO MAINTAIN,PARTIAL VACATE ORDER ISSUED                                              P
+2/21/2012,2012,18-03,DECATUR STREET,Queens,11385,3578,62,SRO - ILLEGAL WORK/NO PERMIT/CHANGE IN OCCUP-USE                          +,PARTIAL VACATE ORDER ISSUED                                              P
+2/22/2012,2012,175-39,UNDERHILL AVENUE,Queens,11365,5589,39,ILLEGAL CONVERSION                                                        +,PARTIAL VACATE ORDER ISSUED                                              P
+2/22/2012,2012,129-18, 101 AVENUE,Queens,11419,9497,4,ILLEGAL CONVERSION                                                        +,PARTIAL VACATE ORDER ISSUED                                              P
+2/22/2012,2012,135-01,LIBERTY AVENUE,Queens,11419,9503,52,ILLEGAL CONVERSION                                                        +,PARTIAL VACATE ORDER ISSUED                                              P
+2/22/2012,2012,89-77, 218 PLACE,Queens,11427,10663,11,SRO - ILLEGAL WORK/NO PERMIT/CHANGE IN OCCUP-USE                          +,PARTIAL VACATE ORDER ISSUED                                              P
+2/23/2012,2012,115-62,NEWBURG STREET,Queens,11412,10398,40,DEBRIS/BUILDING - FALLING OR IN DANGER OF FALLING,FULL VACATE ORDER ISSUED                                                 F
+2/23/2012,2012,137-29,223 STREET,Queens,11413,13129,19,ILLEGAL CONVERSION                                                        +,PARTIAL VACATE ORDER ISSUED                                              P
+2/24/2012,2012,2847,BRIGHTON    3 STREET,Brooklyn,11235,7261,25,BUILDING SHAKING/VIBRATING/STRUCT STABILITY AFFECTED,FULL VACATE ORDER ISSUED                                                 F
+2/24/2012,2012,105-42,OTIS AVENUE,Queens,11368,1959,9,ILLEGAL CONVERSION                                                        +,PARTIAL VACATE ORDER ISSUED                                              P
+2/24/2012,2012,145-06,123 AVENUE,Queens,11436,12048,103,BUILDING SHAKING/VIBRATING/STRUCT STABILITY AFFECTED,FULL VACATE ORDER ISSUED                                                 F
+2/24/2012,2012,145-08,123 AVENUE,Queens,11436,12048,104,BUILDING SHAKING/VIBRATING/STRUCT STABILITY AFFECTED,FULL VACATE ORDER ISSUED                                                 F
+2/27/2012,2012,147-44,FERNDALE AVENUE,Queens,11435,11949,320,SRO - ILLEGAL WORK/NO PERMIT/CHANGE IN OCCUP-USE                          +,PARTIAL VACATE ORDER ISSUED                                              P
+2/27/2012,2012,166-02, 116 AVENUE,Queens,11434,12348,120,SRO - ILLEGAL WORK/NO PERMIT/CHANGE IN OCCUP-USE                          +,PARTIAL VACATE ORDER ISSUED                                              P
+2/29/2012,2012,39,MOTT STREET,Manhattan,10013,164,31,CERTIFICATE OF OCCUPANCY - NONE/ILLEGAL/CONTRARY TO CO,PARTIAL VACATE ORDER ISSUED                                              P
+2/29/2012,2012,242-22,132 AVENUE,Queens,11422,12977,29,ILLEGAL CONVERSION                                                        +,PARTIAL VACATE ORDER ISSUED                                              P
+2/29/2012,2012,305,BEACH 70 STREET,Queens,11692,16083,34,ILLEGAL CONVERSION                                                        +,PARTIAL VACATE ORDER ISSUED                                              P
+3/1/2012,2012,201,EAST FORDHAM ROAD,Bronx,10458,3154,1,FAILURE TO MAINTAIN,PARTIAL VACATE ORDER ISSUED                                              P
+3/1/2012,2012,317,EAST   31 STREET,Brooklyn,11226,4948,82,ILLEGAL CONVERSION                                                        +,PARTIAL VACATE ORDER ISSUED                                              P
+3/1/2012,2012,32-27,105 STREET,Queens,11369,1700,60,ILLEGAL CONVERSION                                                        +,FULL VACATE ORDER ISSUED                                                 F

--- a/src/tests/integration/test_nycdb.py
+++ b/src/tests/integration/test_nycdb.py
@@ -617,3 +617,17 @@ def test_dcp_housingdb(conn):
         rec = curs.fetchone()
         assert rec is not None
         assert rec['latitude'] == Decimal('40.796734999999998')
+
+
+def test_dob_vacate_orders(conn):
+    drop_table(conn, 'dob_vacate_orders')
+    dataset = nycdb.Dataset('dob_vacate_orders', args=ARGS)
+    dataset.db_import()
+    assert row_count(conn, 'dob_vacate_orders') > 0
+    assert has_one_row(conn, "select 1 where to_regclass('public.dob_vacate_orders_bbl_idx') is NOT NULL")
+
+    with conn.cursor(cursor_factory=psycopg2.extras.DictCursor) as curs:
+        curs.execute("select * from dob_vacate_orders WHERE bbl = '4029700038'")
+        rec = curs.fetchone()
+        assert rec is not None
+        assert rec['streetname'] == '83 STREET'

--- a/src/tests/integration/test_nycdb.py
+++ b/src/tests/integration/test_nycdb.py
@@ -630,4 +630,4 @@ def test_dob_vacate_orders(conn):
         curs.execute("select * from dob_vacate_orders WHERE bbl = '4029700038'")
         rec = curs.fetchone()
         assert rec is not None
-        assert rec['streetname'] == '83 STREET'
+        assert rec['lastdispositiondate'].strftime('%Y-%m-%d') == '2012-01-03'

--- a/src/tests/unit/test_typecast.py
+++ b/src/tests/unit/test_typecast.py
@@ -68,6 +68,7 @@ def test_date_invalid_yyyymmdd_string():
 
 def test_date_mm_dd_yyyy():
     assert typecast.date('05/01/1925') == datetime.date(1925, 5, 1)
+    assert typecast.date('5/1/1925') == datetime.date(1925, 5, 1)
 
 
 def test_date_iso8601_string():


### PR DESCRIPTION
This PR adds a new DOB Vacate Orders dataset (#195) from @jennahgosciak's [FOIL request](https://github.com/jennahgosciak/dob_vacate_orders)

The dates in this file are formatted as `m/d/yyyy`, without zero padding on the months and days, so I needed to adjust `date()` in [src/nycdb/typecast.py](src/nycdb/typecast.py)