### PR TITLE
delete print statement from debugging

### DIFF
--- a/src/nycdb/typecast.py
+++ b/src/nycdb/typecast.py
@@ -241,5 +241,3 @@ class Typecast():
             else:
                 d[k] = lambda x: x
         return d
-
-print(date('1/3/2012'))


### PR DESCRIPTION
There was a print statement that must have been from some debugging that got accidentally committed - this just deletes that line