### PR TITLE
use multi-row insert statement instead of many single-row ones

### DIFF
--- a/src/nycdb/database.py
+++ b/src/nycdb/database.py
@@ -24,7 +24,7 @@ class Database:
         }
 
         self.table_name = table_name
-        self.conn = psycopg.connect(self.conninfo())
+        self.conn = psycopg.connect(self.conninfo(), cursor_factory=psycopg.ClientCursor)
 
     def sql(self, SQL):
         """executes single sql statement"""
@@ -42,10 +42,7 @@ class Database:
 
         with self.conn.cursor() as curs:
             try:
-                curs.executemany(
-                    sql.insert_many(table_name, rows),
-                    map(lambda d: list(d.values()), rows),
-                )
+                curs.execute(sql.insert_many(curs, table_name, rows))
             except psycopg.Error:
                 print(rows)  # useful for debugging
                 raise

--- a/src/nycdb/sql.py
+++ b/src/nycdb/sql.py
@@ -8,25 +8,26 @@ def create_table(table_name, fields) -> str:
     return sql
 
 
-def insert_many(table_name, rows) -> str:
+def insert_many(curs, table_name, rows) -> str:
     """
-    Given a table name and a list of dictionaries representing
-    rows, generate a (sql, template) tuple of strings that can be
-    passed to psycopg2.extras.execute_values() [1] to bulk insert all the
-    values for improved efficiency [2].
+    Given a psycopg.ClientCursor, a table name, and a list of dictionaries
+    representing rows, generate a sql statement string that already has the
+    parameters safely formatted using mogrify. This statement can be passed to
+    psycopg.execute to bulk insert all the values for improved efficiency. [1]
 
     For example:
 
-        >>> insert_many('boop', [{'foo': 1, 'bar': 2}])
-        ('INSERT INTO boop (foo, bar) VALUES %s', '(%(foo)s, %(bar)s)')
+        >>> insert_many(curs, 'boop', [{'foo': 1, 'bar': 2}, {'foo': 3, 'bar': 4}])
+        'INSERT INTO boop (foo, bar) VALUES (1,2), (3,4)'
 
-    [1]: http://initd.org/psycopg/docs/extras.html#psycopg2.extras.execute_values
-    [2]: https://stackoverflow.com/a/30985541
+    [1]:
+    https://www.geeksforgeeks.org/format-sql-in-python-with-psycopgs-mogrify/
     """
 
-    field_names = list(rows[0].keys())
-    fields = ",".join(field_names)
-    values = ",".join(["%s" for k in field_names])
-    sql = f"INSERT INTO {table_name} ({fields}) VALUES ({values})"
+    field_names = rows[0].keys()
+    placeholder = f"({','.join(['%s' for k in field_names])})"
+    fields = placeholder % tuple(field_names)
+    values = ",".join(curs.mogrify(placeholder, tuple(row.values())) for row in rows)
+    sql = f"INSERT INTO {table_name} {fields} VALUES {values}"
 
     return sql


### PR DESCRIPTION
I believe that psycopg's `executemany` sends a separate transaction for each INSERT statement that we're passing it, and while this didn't seem to affect the speed too much when running locally, when connecting to a remote db it was extremely slow. I believe what the old `psycopg2.extras.execute_values` did was concatenate all of the individual insert statements then send them all at once as a single transaction, so this was much faster. With the new psycopg3 those extras aren't available, so I instead created a single INSERT statement (safely binding the parameters with `mogrify`) that adds multiple rows, and then this can be run with just `execute`. Testing locally on a full pluto table and a remote db, this appears to get us back to roughly the old speed. 

To use `mogrify` I needed to specify the [ClientCursor subclass](https://www.psycopg.org/psycopg3/docs/api/cursors.html#the-clientcursor-class), but that doesn't seem to be an issue.

I've now tested this change with the auto-updater and everything seems to be working and back to normal times for the jobs, so we should be good to merge after review. 

Seperately, I'm having some issues with the new `pluto_22v1` & `pluto_23v1` jobs exceeding memory limits, but I tried going back to psycopg2 (https://github.com/nycdb/nycdb/compare/main...revert-to-psycopg2) and that didn't make any difference. So later I might look into memory usage for nycdb dataset jobs and/or just allocate more memory on our kubernetes (#267).