### PR TITLE
CLI --drop command

### DIFF
--- a/src/README.md
+++ b/src/README.md
@@ -24,6 +24,8 @@ nycdb --load hpd_violations
 nycdb --verify hpd_violations
 ```
 
+To delete a previously imported dataset (for example, if you'd like to import an updated version of it), use the `--drop` option. For example, to delete the dataset **hpd_violations**: `nycdb --drop hpd_violations`.
+
 You can also verify all datasets: ` nycdb --verify-all `
 
 By default the downloaded data files are is stored in `./data`. Use `--root-dir` to change the location of the data directory.

--- a/src/nycdb/cli.py
+++ b/src/nycdb/cli.py
@@ -21,6 +21,7 @@ def parse_args():
     parser.add_argument('--load', metavar='DATASET', action='store', help='loads dataset into postgres')
     parser.add_argument('--verify', metavar='DATASET', action='store', help='verifies a dataset by checking the table row count')
     parser.add_argument('--dump', metavar='DATASET', action='store', help='creates a sql dump of the datasets in the current folder')
+    parser.add_argument('--drop', metavar='DATASET', action='store', help='deletes a dataset from postgres')
     # list and verify
     parser.add_argument('--list-datasets', action='store_true', help='lists all datasets')
     parser.add_argument('--verify-all', action='store_true', help='verifies all datasets')
@@ -104,6 +105,8 @@ def dispatch(args):
         Dataset(args.dump, args=args).dump()
     elif args.dbshell:
         run_dbshell(args=args)
+    elif args.drop:
+        Dataset(args.drop, args=args).drop()
 
 def main():
     logging.basicConfig(level=logging.DEBUG)

--- a/src/nycdb/dataset.py
+++ b/src/nycdb/dataset.py
@@ -166,6 +166,17 @@ class Dataset:
         cmd = ["pg_dump", "--no-owner", "--clean", "--if-exists", "-w"] + tables + [file_arg]
         subprocess.run(cmd, env=self.pg_env(), check=True)
 
+
+    def drop(self):
+        """
+        Drops the dataset from postgres.
+        """
+        self.setup_db()
+
+        for s in self.schemas:
+            self.db.sql(sql.drop_table(s['table_name']))
+
+
     def pg_env(self):
         """
         Returns a copy of the environment with postgres environment variables set

--- a/src/nycdb/sql.py
+++ b/src/nycdb/sql.py
@@ -7,6 +7,12 @@ def create_table(table_name, fields) -> str:
     sql += ")"
     return sql
 
+def drop_table(table_name) -> str:
+    """
+    String --> String
+    """
+    return "DROP TABLE {}".format(table_name)
+
 
 def insert_many(curs, table_name, rows) -> str:
     """


### PR DESCRIPTION
Adds support for a `--drop` command, e.g. `nycdb --drop hpd_violations`, which drops the dataset's tables from the database. Primarily meant to improve the experience of adding a new dataset.