### PR TITLE
Fix dob safety violations url

### DIFF
--- a/src/nycdb/datasets/dob_safety_violations.yml
+++ b/src/nycdb/datasets/dob_safety_violations.yml
@@ -1,7 +1,7 @@
 ---
 files:
   -
-    url: https://data.cityofnewyork.us/api/views/855j-jady/rows.csv?date=20240120&accessType=DOWNLOAD
+    url: https://data.cityofnewyork.us/api/views/855j-jady/rows.csv?accessType=DOWNLOAD
     dest: dob_safety_violations.csv
 schema:
   table_name: dob_safety_violations

--- a/src/nycdb/sql/dob_safety_violations.sql
+++ b/src/nycdb/sql/dob_safety_violations.sql
@@ -1,1 +1,3 @@
 CREATE INDEX dob_safety_violations_bbl_idx on dob_safety_violations (bbl);
+CREATE INDEX dob_safety_violations_violationissuedate_idx on dob_safety_violations (violationissuedate);
+CREATE INDEX dob_safety_violations_violationnumber_idx on dob_safety_violations (violationnumber);


### PR DESCRIPTION
There was an extra url param in the yaml for the dataset `dob_safety_violations` and this meant we weren't getting all the records

While I was at it I thought I'd add a couple extra indexes to the sql for some columns that seemed useful