### PR TITLE
add indexes on boundaries, construct geom on pluto_latest

### DIFF
--- a/src/nycdb/datasets/boundaries.yml
+++ b/src/nycdb/datasets/boundaries.yml
@@ -30,7 +30,8 @@ files:
     dest: nyfb_23d.zip
   - url: https://s-media.nyc.gov/agencies/dcp/assets/files/zip/data-tools/bytes/nyfd_23d.zip
     dest: nyfd_23d.zip
-sql: []
+sql: 
+  - boundaries.sql
 schema:
   # State Assembly Districts
   - table_name: nyad

--- a/src/nycdb/datasets/pluto_latest.yml
+++ b/src/nycdb/datasets/pluto_latest.yml
@@ -96,7 +96,6 @@ schema:
     HealthCenterDistrict: smallint
     Firm07Flag: char(1)
     pfirm15flag: char(1)
-    geom: text
     dcpedited: text
     Notes: text
     BCT2020: text
@@ -111,3 +110,4 @@ schema:
     - masdate
     - polidate
     - edesigdate
+    - geom

--- a/src/nycdb/sql/boundaries.sql
+++ b/src/nycdb/sql/boundaries.sql
@@ -1,0 +1,15 @@
+CREATE INDEX nyad_geom_idx ON nyad USING GIST (geom);
+CREATE INDEX nycg_geom_idx ON nycg USING GIST (geom);
+CREATE INDEX nyss_geom_idx ON nyss USING GIST (geom);
+CREATE INDEX nymc_geom_idx ON nymc USING GIST (geom);
+CREATE INDEX nycc_geom_idx ON nycc USING GIST (geom);
+CREATE INDEX nyed_geom_idx ON nyed USING GIST (geom);
+CREATE INDEX nybb_geom_idx ON nybb USING GIST (geom);
+CREATE INDEX nycd_geom_idx ON nycd USING GIST (geom);
+CREATE INDEX nysd_geom_idx ON nysd USING GIST (geom);
+CREATE INDEX nypp_geom_idx ON nypp USING GIST (geom);
+CREATE INDEX nyha_geom_idx ON nyha USING GIST (geom);
+CREATE INDEX nyhc_geom_idx ON nyhc USING GIST (geom);
+CREATE INDEX nyfc_geom_idx ON nyfc USING GIST (geom);
+CREATE INDEX nyfb_geom_idx ON nyfb USING GIST (geom);
+CREATE INDEX nyfd_geom_idx ON nyfd USING GIST (geom);

--- a/src/nycdb/sql/pluto_latest.sql
+++ b/src/nycdb/sql/pluto_latest.sql
@@ -20,3 +20,8 @@ UPDATE pluto_latest SET landusedesc = CASE
       ELSE '9999'
       END;
 CREATE INDEX pluto_latest_bbl_idx on pluto_latest (bbl);
+
+SELECT AddGeometryColumn ('pluto_latest','geom', 2263, 'POINT', 2);
+UPDATE pluto_latest SET 
+  geom = ST_Transform(ST_SetSRID(ST_MakePoint(longitude, latitude), 4326), 2263);
+CREATE INDEX pluto_latest_geom_idx on pluto_latest using GIST (geom);

--- a/src/tests/integration/test_nycdb.py
+++ b/src/tests/integration/test_nycdb.py
@@ -240,6 +240,9 @@ def test_pluto_latest(conn):
     pluto = nycdb.Dataset("pluto_latest", args=ARGS)
     pluto.db_import()
     assert row_count(conn, "pluto_latest") == 5
+    assert has_one_row(
+        conn, "select 1 where to_regclass('public.pluto_latest_geom_idx') is NOT NULL"
+    )
 
 
 def test_pluto_sql_columns(conn):
@@ -771,6 +774,9 @@ def test_boundaries_one(conn):
     boundaries.db_import(limit=['nyad'])
     assert row_count(conn, 'nyad') == 5
     assert get_srid(conn, 'nyad', 'geom') == 2263
+    assert has_one_row(
+        conn, "select 1 where to_regclass('public.nyad_geom_idx') is NOT NULL"
+    )
 
 
 def test_boundaries_two(conn):

--- a/src/tests/integration/test_nycdb.py
+++ b/src/tests/integration/test_nycdb.py
@@ -774,7 +774,7 @@ def test_shapefile_in_alt_schema_works(conn):
     boundaries.setup_db()
     default_search_path = boundaries.db.execute_and_fetchone("SHOW search_path")
     boundaries.db.sql("CREATE SCHEMA IF NOT EXISTS temp; SET search_path TO temp, public")
-    boundaries.db_import(limit=['nyad'])
+    boundaries.db_import()
     query = "SELECT table_schema FROM information_schema.columns WHERE table_name='nyad'"
     assert boundaries.db.execute_and_fetchone(query) == "temp"
     boundaries.db.sql(f'DROP SCHEMA temp CASCADE; SET search_path TO {default_search_path}')

--- a/src/tests/integration/test_nycdb.py
+++ b/src/tests/integration/test_nycdb.py
@@ -771,7 +771,7 @@ def test_boundaries_one(conn):
     setup_postgis(conn)
     drop_table(conn, 'nyad')
     boundaries = nycdb.Dataset('boundaries', args=ARGS)
-    boundaries.db_import(limit=['nyad'])
+    boundaries.db_import()
     assert row_count(conn, 'nyad') == 5
     assert get_srid(conn, 'nyad', 'geom') == 2263
     assert has_one_row(
@@ -784,7 +784,7 @@ def test_boundaries_two(conn):
     drop_table(conn, 'nyad')
     drop_table(conn, 'nycc')
     boundaries = nycdb.Dataset('boundaries', args=ARGS)
-    boundaries.db_import(limit=['nyad', 'nycc'])
+    boundaries.db_import()
     assert row_count(conn, 'nyad') == 5
     assert row_count(conn, 'nycc') == 5
     assert get_srid(conn, 'nycc', 'geom') == 2263
@@ -797,7 +797,7 @@ def test_shapefile_in_alt_schema_works(conn):
     boundaries.setup_db()
     default_search_path = boundaries.db.execute_and_fetchone("SHOW search_path")
     boundaries.db.sql("CREATE SCHEMA IF NOT EXISTS temp; SET search_path TO temp, public")
-    boundaries.db_import(limit=['nyad'])
+    boundaries.db_import()
     query = "SELECT table_schema FROM information_schema.columns WHERE table_name='nyad'"
     assert boundaries.db.execute_and_fetchone(query) == "temp"
     boundaries.db.sql(f'DROP SCHEMA temp CASCADE; SET search_path TO {default_search_path}')


### PR DESCRIPTION
This adds spatial indexes for all of the tables in our `boundaries` dataset, to help speed up spatial joins and other operations. 

This also skips the `geom` column when loading `pluto_latest`, since it's all empty, and instead uses the post-load sql to generate a spatial column for lot centroid from the lat/long columns. 