### PR TITLE
remove broken geom column for pluto_latest

### DIFF
--- a/src/nycdb/sql/pluto_latest.sql
+++ b/src/nycdb/sql/pluto_latest.sql
@@ -20,8 +20,3 @@ UPDATE pluto_latest SET landusedesc = CASE
       ELSE '9999'
       END;
 CREATE INDEX pluto_latest_bbl_idx on pluto_latest (bbl);
-
-SELECT AddGeometryColumn ('pluto_latest','geom', 2263, 'POINT', 2);
-UPDATE pluto_latest SET 
-  geom = ST_Transform(ST_SetSRID(ST_MakePoint(longitude, latitude), 4326), 2263);
-CREATE INDEX pluto_latest_geom_idx on pluto_latest using GIST (geom);

--- a/src/tests/integration/test_nycdb.py
+++ b/src/tests/integration/test_nycdb.py
@@ -252,9 +252,6 @@ def test_pluto_latest(conn):
     pluto = nycdb.Dataset("pluto_latest", args=ARGS)
     pluto.db_import()
     assert row_count(conn, "pluto_latest") == 5
-    assert has_one_row(
-        conn, "select 1 where to_regclass('public.pluto_latest_geom_idx') is NOT NULL"
-    )
 
 
 def test_pluto_sql_columns(conn):


### PR DESCRIPTION
Previously we had tried to add a geometry column for pluto_latest using the lat/lon coordinates and the postgis function AddGeometryColumn, but something is not working with that and it's breaking another project that depends on NYCDB. Since the column wasn't working anyway I'm going to just remove it now and will make an issue fixing it and adding it back later.