### PR TITLE
HPD LL44: BBL use raw data for bbl column, add boroid

### DIFF
--- a/src/nycdb/dataset_transformations.py
+++ b/src/nycdb/dataset_transformations.py
@@ -248,7 +248,7 @@ def hpd_underlying_conditions(dataset):
 
 def hpd_ll44_buildings(dataset):
     fields_to_skip = [s.lower() for s in dataset.schemas[0].get('skip')]
-    return with_bbl(skip_fields(to_csv(dataset.files[0].dest), fields_to_skip))
+    return skip_fields(to_csv(dataset.files[0].dest), fields_to_skip)
 
 def hpd_ll44_projects(dataset):
     return to_csv(dataset.files[1].dest)

--- a/src/nycdb/datasets/hpd_ll44.yml
+++ b/src/nycdb/datasets/hpd_ll44.yml
@@ -39,7 +39,7 @@ schema:
       Postcode: char(5)
       bbl: char(10)
     skip:
-      - Bbl
+      - Borough
   -
     table_name: hpd_ll44_projects
     fields:

--- a/src/nycdb/datasets/hpd_ll44.yml
+++ b/src/nycdb/datasets/hpd_ll44.yml
@@ -30,6 +30,7 @@ schema:
       Totalbuildingunits: integer
       Basesquarefootage: integer
       Stories: integer
+      bbl: char(10)
       CommunityBoard: text
       CouncilDistrict: text
       CensusTract: text
@@ -37,7 +38,6 @@ schema:
       Latitude: numeric
       Longitude: numeric
       Postcode: char(5)
-      bbl: char(10)
     skip:
       - Borough
   -

--- a/src/nycdb/sql/hpd_ll44.sql
+++ b/src/nycdb/sql/hpd_ll44.sql
@@ -1,3 +1,6 @@
+ALTER TABLE hpd_ll44_buildings ADD COLUMN boroid int;
+UPDATE hpd_ll44_buildings SET boroid = substr(bin, 1, 1)::int;
+
 CREATE INDEX hpd_ll44_buildings_bbl_idx on hpd_ll44_buildings (bbl);
 CREATE INDEX hpd_ll44_buildings_projectid_idx on hpd_ll44_buildings (projectid);
 CREATE INDEX hpd_ll44_buildings_buildingid_idx on hpd_ll44_buildings (buildingid);

--- a/src/nycdb/sql/hpd_ll44.sql
+++ b/src/nycdb/sql/hpd_ll44.sql
@@ -1,5 +1,5 @@
 ALTER TABLE hpd_ll44_buildings ADD COLUMN boroid int;
-UPDATE hpd_ll44_buildings SET boroid = substr(bin, 1, 1)::int;
+UPDATE hpd_ll44_buildings SET boroid = nullif(substr(bin, 1, 1), '')::int;
 
 CREATE INDEX hpd_ll44_buildings_bbl_idx on hpd_ll44_buildings (bbl);
 CREATE INDEX hpd_ll44_buildings_projectid_idx on hpd_ll44_buildings (projectid);

--- a/src/tests/integration/test_nycdb.py
+++ b/src/tests/integration/test_nycdb.py
@@ -875,6 +875,8 @@ def test_hpd_ll44(conn):
         rec = curs.fetchone()
         assert rec is not None
         assert rec['projectid'] == 44218
+        assert rec['bbl'] == '1017900046'
+        assert rec['boroid'] == 1
 
     assert row_count(conn, 'hpd_ll44_projects') > 0
     assert has_one_row(conn, "select 1 where to_regclass('public.hpd_ll44_projects_projectid_idx') is NOT NULL")


### PR DESCRIPTION
Initially I noticed missing BBL values in some records, and thought it was better to skip it and add it via the separate boro/block/lot, but didn't realize the borough was missing as well. So going back to just using the original BBL column from the raw data and fixing the missing borough values via sql