### PR TITLE
update dataset url for new nyc open data domain

### DIFF
--- a/src/nycdb/datasets/dob_certificate_occupancy.yml
+++ b/src/nycdb/datasets/dob_certificate_occupancy.yml
@@ -1,7 +1,7 @@
 ---
 files:
   -
-    url: https://nycopendata.socrata.com/api/views/bs8b-p36w/rows.csv?accessType=DOWNLOAD
+    url: https://data.cityofnewyork.us/api/views/bs8b-p36w/rows.csv?accessType=DOWNLOAD
     dest: dob_certificate_occupancy.csv
   -
     url: https://justfix-data.s3.amazonaws.com/FOIL_2024-810-4230_COList_2000-2012.csv

--- a/src/nycdb/datasets/dob_complaints.yml
+++ b/src/nycdb/datasets/dob_complaints.yml
@@ -1,7 +1,7 @@
 ---
 files:
   -
-    url: https://nycopendata.socrata.com/api/views/eabe-havv/rows.csv?accessType=DOWNLOAD
+    url: https://data.cityofnewyork.us/api/views/eabe-havv/rows.csv?accessType=DOWNLOAD
     dest: dob_complaints.csv
 schema:
   table_name: dob_complaints


### PR DESCRIPTION
Yesterday we got an error on download the dob_complaints dataset - it is a certificate error, and after reporting it via NYC Open Data portal the DOB person explained that the `nycopendata.socrata.com` domain is old and we should update to use `data.cityofnewyork.us` instead. And this seems to work. (Though I also got an error at first when trying to download it directly from the portal using the export button, so not totally sure and may need to revisit this).

`dob_complaints` and `dob_certificate_occupancy` were the only two datasets still using this old domain. 