### PR TITLE
add executed evictions dataset

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ Residents, lawyers, tenants, and organizers who want to use data in their strugg
 - [Tax bills - Rent Stabilization Unit Counts](https://github.com/nycdb/nycdb/wiki/Dataset:-Rent-Stabilized-Buildings) ([John Krauss](https://github.com/talos/nyc-stabilization-unit-counts) and [Atul Varma's](https://github.com/JustFixNYC/nyc-doffer) data)
 - [DOF Tax Lien Sale List](https://github.com/nycdb/nycdb/wiki/Dataset:-DOF-Tax-Lien-Sale-List)
 - [ACRIS](https://github.com/nycdb/nycdb/wiki/Dataset:-ACRIS)
+- [Executed Evictions](https://github.com/nycdb/nycdb/wiki/Dataset:-Executed-Evictions) - Direct from Open Data
 - [Marshal Evictions](https://github.com/nycdb/nycdb/wiki/Dataset:-Marshal-Evictions) - From [DOI](https://data.cityofnewyork.us/City-Government/Evictions/6z8x-wfk4) via ANHD's [Displacement Alert Project](https://github.com/ANHD-NYC-CODE/anhd-council-backend) and [API](https://api.displacementalert.org/docs/) (built by [Jade Ahking](https://github.com/0xStarcat))
 - [ECB Violations](https://github.com/nycdb/nycdb/wiki/Dataset:-ECB-Violations)
 - [Oath Hearings](https://github.com/nycdb/nycdb/wiki/Dataset:-OATH-Hearings)

--- a/src/nycdb/dataset_transformations.py
+++ b/src/nycdb/dataset_transformations.py
@@ -301,3 +301,7 @@ def fc_shd_building(dataset):
 
 def dos_active_corporations(dataset):
     return to_csv(dataset.files[0].dest)
+
+
+def executed_evictions(dataset):
+    return to_csv(dataset.files[0].dest)

--- a/src/nycdb/datasets/executed_evictions.yml
+++ b/src/nycdb/datasets/executed_evictions.yml
@@ -1,0 +1,31 @@
+---
+files:
+  -
+    url: https://data.cityofnewyork.us/api/views/6z8x-wfk4/rows.csv?accessType=DOWNLOAD
+    dest: executed_evictions.csv
+sql:
+    - executed_evictions.sql
+schema:
+  table_name: executed_evictions
+  verify_count: 105_000
+  fields:
+    CourtIndexNumber: text
+    DocketNumber: text
+    EvictionAddress: text
+    EvictionApartmentNumber: text
+    ExecutedDate: date
+    MarshalFirstName: text
+    MarshalLastName: text
+    ResidentialCommercial: text
+    Borough: text
+    EvictionPostcode: text
+    Ejectment: text
+    EvictionLegalPossession: text
+    Latitude: numeric
+    Longitude: numeric
+    CommunityBoard: text
+    CouncilDistrict: text
+    CensusTract: text
+    Bin: char(7)
+    Bbl: char(10)
+    Nta: text

--- a/src/nycdb/sql/executed_evictions.sql
+++ b/src/nycdb/sql/executed_evictions.sql
@@ -1,0 +1,3 @@
+CREATE INDEX executed_evictions_bbl_idx on executed_evictions (bbl);
+CREATE INDEX executed_evictions_courtindexnumber_idc on executed_evictions (courtindexnumber);
+CREATE INDEX executed_evictions_executeddate_idc on executed_evictions (executeddate);

--- a/src/tests/integration/data/executed_evictions.csv
+++ b/src/tests/integration/data/executed_evictions.csv
@@ -1,0 +1,11 @@
+Court Index Number,Docket Number ,Eviction Address,Eviction Apartment Number,Executed Date,Marshal First Name,Marshal Last Name,Residential/Commercial,BOROUGH,Eviction Postcode,Ejectment,Eviction/Legal Possession,Latitude,Longitude,Community Board,Council District,Census Tract,BIN,BBL,NTA
+306810/22K,120701,824 EAST NEW YORK AV ENUE,5M,02/26/2024,Justin,Grossman,Residential,BROOKLYN,11203,Not an Ejectment,Possession,40.662499,-73.935567,9,41,876,3107130,3048060077,Prospect Lefferts Gardens-Wingate
+336507/22,129124,1632 HUTCHINSON  RIV ER PARKWAY,2B,10/03/2024,Justin,Grossman,Residential,BRONX,10461,Not an Ejectment,Possession,,,,,,,,
+K86326/17B,085778,124 SUMPTER STREET,2,05/15/2018,Ileana,Rivera,Residential,BROOKLYN,11233,Not an Ejectment,Possession,40.679938,-73.920372,3,41,379,3347892,3015240128,Stuyvesant Heights
+312998/22,022558,746 EAST 98 ST AKA 746-748 EAST 98 ST,,01/06/2023,George,"Essock, Jr.",Commercial,BROOKLYN,11236,Not an Ejectment,Possession,40.651907,-73.908372,17,42,1098,3228510,3081230047,East New York
+305563/23,064295,10-25 MCBRIDE STREET,,11/02/2023,Howard,Schain,Residential,QUEENS,11691,Not an Ejectment,Possession,40.603087,-73.758027,14,31,100802,4300306,4157140137,Far Rockaway-Bayswater
+N66680/17,081024,87 HAMILTON PLACE,2B,11/22/2017,Ileana,Rivera,Residential,MANHATTAN,10031,Not an Ejectment,Possession,40.823008,-73.950670,9,7,225,1061772,1020720039,Hamilton Heights
+B17542/18,109030,20 METROPOLITAN OVAL,7B,10/17/2018,Darlene,Barone,Residential,BRONX,10462,Not an Ejectment,Possession,40.838229,-73.859121,9,18,21002,2096698,2039437501,Parkchester
+53549/19,490126,1113 YORK AVE AKA TW O SUTTON PLACE NORTH,36B,05/30/2019,Danny,Weinheim,Residential,MANHATTAN,10065,Not an Ejectment,Possession,40.759383,-73.959207,8,5,10602,1045277,1014550021,Lenox Hill-Roosevelt Island
+70530/17,14203,422 BEACH 28TH STREET,1,02/22/2018,Edward,Guida,Residential,QUEENS,11691,Not an Ejectment,Possession,40.598055,-73.761621,14,31,99801,4301450,4157910033,Far Rockaway-Bayswater
+300205/24,40253,139 BRABANT ST.,06B,08/21/2024,Edward,Guida,Residential,STATEN ISLAND,10303,Not an Ejectment,Eviction,40.631816,-74.162942,1,49,31901,5109120,5012450001,Mariner's Harbor-Arlington-Port Ivory-Graniteville

--- a/src/tests/integration/test_nycdb.py
+++ b/src/tests/integration/test_nycdb.py
@@ -990,3 +990,16 @@ def test_dof_property_valuation_and_assessments(conn):
         rec = curs.fetchone()
         assert rec is not None
         assert rec['extracrdt'].strftime("%Y-%m-%d") == '2023-05-17'
+
+
+def test_executed_evictions(conn):
+    dataset = nycdb.Dataset('executed_evictions', args=ARGS)
+    dataset.drop()
+    dataset.db_import()
+    assert row_count(conn, 'executed_evictions') == 10
+    assert has_one_row(conn, "select 1 where to_regclass('public.executed_evictions_bbl_idx') is NOT NULL")
+    with conn.cursor(row_factory=dict_row) as curs:
+        curs.execute("select * from executed_evictions WHERE bbl = '3048060077'")
+        rec = curs.fetchone()
+        assert rec is not None
+        assert rec['executeddate'].strftime("%Y-%m-%d") == '2024-02-26'


### PR DESCRIPTION
This dataset comes directly from open data, with no changes. We also have another dataset, [`marshals_evictions`](https://github.com/nycdb/nycdb/wiki/Dataset:-Marshal-Evictions) which includes some additional geocoding and cleaning to address duplicates. When the evictions data was first published the BBL ([borough-block-lot](https://github.com/nycdb/nycdb/wiki/Glossary#borough-block-lot-bbl), property identifier) was not included and there were concerns about duplicate records, so HDC members and ANHD created cleaned versions of the data. Since then the Open Data version now includes geocoding results.

It's possible there are still issues with duplicate records, and I plan to look into this and compare the two sources to see if we can transition to using this unaltered Open Data version in all cases. 