### PR TITLE
add SQL-only dataset with dependencies for pluto_latest_districts

### DIFF
--- a/src/nycdb/dataset.py
+++ b/src/nycdb/dataset.py
@@ -46,9 +46,7 @@ class Dataset:
 
         self.dataset = datasets()[dataset_name]
         self.files = self._files()
-        self.schemas = (
-            list_wrap(self.dataset["schema"]) if "schema" in self.dataset else []
-        )
+        self.schemas = list_wrap(self.dataset["schema"])
         self.dependencies = (
             list_wrap(self.dataset["dependencies"]) if "dependencies" in self.dataset else []
         )

--- a/src/nycdb/dataset.py
+++ b/src/nycdb/dataset.py
@@ -48,7 +48,9 @@ class Dataset:
         self.files = self._files()
         self.schemas = list_wrap(self.dataset["schema"])
         self.dependencies = (
-            list_wrap(self.dataset["dependencies"]) if "dependencies" in self.dataset else []
+            list_wrap(self.dataset["dependencies"])
+            if "dependencies" in self.dataset
+            else []
         )
 
     def _files(self):
@@ -86,7 +88,7 @@ class Dataset:
                 for dep_schema in dep_dataset.schemas:
                     if not self.db.table_exists(dep_schema["table_name"]):
                         raise Exception(
-                            f"Missing dataset dependency. '{"','".join(self.dependencies)}' datasets must be loaded first."
+                            f"Missing dataset dependency. {','.join(self.dependencies)} datasets must be loaded first."
                         )
 
         for schema in self.schemas:

--- a/src/nycdb/dataset.py
+++ b/src/nycdb/dataset.py
@@ -46,9 +46,13 @@ class Dataset:
 
         self.dataset = datasets()[dataset_name]
         self.files = self._files()
-        self.schemas = list_wrap(self.dataset["schema"])
+        self.schemas = (
+            list_wrap(self.dataset["schema"]) if "schema" in self.dataset else []
+        )
 
     def _files(self):
+        if "files" not in self.dataset:
+            return []
         return [
             File(file_dict, folder=self.name, root_dir=self.root_dir)
             for file_dict in self.dataset["files"]

--- a/src/nycdb/datasets/pluto_latest_districts.yml
+++ b/src/nycdb/datasets/pluto_latest_districts.yml
@@ -1,0 +1,3 @@
+---
+sql:
+  - pluto_latest_districts.sql

--- a/src/nycdb/datasets/pluto_latest_districts.yml
+++ b/src/nycdb/datasets/pluto_latest_districts.yml
@@ -4,3 +4,6 @@ sql:
 schema:
   table_name: pluto_latest_districts
   verify_count: 800_000
+dependencies:
+  - pluto_latest
+  - boundaries

--- a/src/nycdb/datasets/pluto_latest_districts.yml
+++ b/src/nycdb/datasets/pluto_latest_districts.yml
@@ -1,3 +1,6 @@
 ---
 sql:
   - pluto_latest_districts.sql
+schema:
+  table_name: pluto_latest_districts
+  verify_count: 800_000

--- a/src/nycdb/datasets/pluto_latest_districts_25a.yml
+++ b/src/nycdb/datasets/pluto_latest_districts_25a.yml
@@ -1,0 +1,3 @@
+---
+sql:
+  - pluto_latest_districts_25a.sql

--- a/src/nycdb/datasets/pluto_latest_districts_25a.yml
+++ b/src/nycdb/datasets/pluto_latest_districts_25a.yml
@@ -4,3 +4,6 @@ sql:
 schema:
   table_name: pluto_latest_districts_25a
   verify_count: 800_000
+dependencies:
+  - pluto_latest
+  - boundaries_25a

--- a/src/nycdb/datasets/pluto_latest_districts_25a.yml
+++ b/src/nycdb/datasets/pluto_latest_districts_25a.yml
@@ -1,3 +1,6 @@
 ---
 sql:
   - pluto_latest_districts_25a.sql
+schema:
+  table_name: pluto_latest_districts_25a
+  verify_count: 800_000

--- a/src/nycdb/sql/pluto_latest.sql
+++ b/src/nycdb/sql/pluto_latest.sql
@@ -23,5 +23,6 @@ ALTER TABLE pluto_latest ADD COLUMN latitudelongitudegeom geometry;
 UPDATE pluto_latest SET latitudelongitudegeom = ST_Point(longitude, latitude, 4326);
 CREATE INDEX pluto_latest_bbl_idx on pluto_latest (bbl);
 CREATE INDEX pluto_latest_ownername_idx on pluto_latest (ownername);
+CREATE INDEX pluto_latest_bct2020_idx on pluto_latest (bct2020);
 CREATE INDEX pluto_latest_latitutde_longitude_idx on pluto_latest (latitude, longitude);
 CREATE INDEX pluto_latest_latitutde_longitude_st_point_gist_idx ON pluto_latest USING GIST (latitudelongitudegeom);

--- a/src/nycdb/sql/pluto_latest_districts.sql
+++ b/src/nycdb/sql/pluto_latest_districts.sql
@@ -23,7 +23,6 @@ CREATE TEMP TABLE IF NOT EXISTS x_pluto_geom AS (
 
 CREATE INDEX ON x_pluto_geom using gist (geom);
 
-DROP TABLE IF EXISTS pluto_latest_districts;
 CREATE TABLE IF NOT EXISTS pluto_latest_districts AS (
 	SELECT
 		p.bbl,

--- a/src/nycdb/sql/pluto_latest_districts.sql
+++ b/src/nycdb/sql/pluto_latest_districts.sql
@@ -1,0 +1,49 @@
+
+-- Creates a table of all BBLs from PLUTO_LATEST with all political districts
+-- spatially joined from BOUNDARIES files. Includes City Council, State
+-- Assembly, State Senate, Congressional districts, Community Districts, 
+-- Zip Codes, Borough, Census Tracts (2010 and 2020) and Neighborhood Tabulation
+-- Areas (NTA) (2010 and 2020).
+
+CREATE TEMP TABLE IF NOT EXISTS x_pluto_geom AS (
+	SELECT
+		p.bbl,
+		p.address,
+		p.zipcode,
+		p.borocode AS borough,
+		p.cd AS community_dist,
+		p.council::TEXT AS coun_dist,
+		p.bct2020 AS boroct2020,
+		ct.nta2020, 
+		ct.ntaname AS nta2020_name,
+		ST_TRANSFORM(ST_SetSRID(ST_MakePoint(longitude, latitude),4326), 2263) AS geom
+	FROM pluto_latest AS p
+	LEFT JOIN nyct2020 AS ct ON bct2020 = boroct2020
+);
+
+CREATE INDEX ON x_pluto_geom using gist (geom);
+
+DROP TABLE IF EXISTS pluto_latest_districts;
+CREATE TABLE IF NOT EXISTS pluto_latest_districts AS (
+	SELECT
+		p.bbl,
+		p.address,
+		p.zipcode,
+		p.borough,
+		p.community_dist,
+		p.coun_dist,
+		p.boroct2020,
+		p.nta2020, 
+		p.nta2020_name,
+		ad.assemdist::text AS assem_dist,
+		ss.stsendist::text AS stsen_dist,
+		cg.congdist::text AS cong_dist,
+		p.geom
+	FROM x_pluto_geom AS p
+	LEFT JOIN nyad AS ad ON ST_Within(p.geom, ad.geom)
+	LEFT JOIN nyss AS ss ON ST_Within(p.geom, ss.geom)
+	LEFT JOIN nycg AS cg ON ST_Within(p.geom, cg.geom)
+);
+
+CREATE INDEX pluto_latest_districts_bbl_idx ON pluto_latest_districts (bbl);
+CREATE INDEX pluto_latest_districts_geom_idx ON pluto_latest_districts using gist (geom);

--- a/src/nycdb/sql/pluto_latest_districts_25a.sql
+++ b/src/nycdb/sql/pluto_latest_districts_25a.sql
@@ -1,0 +1,49 @@
+
+-- Creates a table of all BBLs from PLUTO_LATEST with all political districts
+-- spatially joined from BOUNDARIES files. Includes City Council, State
+-- Assembly, State Senate, Congressional districts, Community Districts, 
+-- Zip Codes, Borough, Census Tracts (2010 and 2020) and Neighborhood Tabulation
+-- Areas (NTA) (2010 and 2020).
+
+CREATE TEMP TABLE IF NOT EXISTS x_pluto_geom AS (
+	SELECT
+		p.bbl,
+		p.address,
+		p.zipcode,
+		p.borocode AS borough,
+		p.cd AS community_dist,
+		p.council::TEXT AS coun_dist,
+		p.bct2020 AS boroct2020,
+		ct.nta2020, 
+		ct.ntaname AS nta2020_name,
+		ST_TRANSFORM(ST_SetSRID(ST_MakePoint(longitude, latitude),4326), 2263) AS geom
+	FROM pluto_latest AS p
+	LEFT JOIN nyct2020_25a AS ct ON bct2020 = boroct2020
+);
+
+CREATE INDEX ON x_pluto_geom using gist (geom);
+
+DROP TABLE IF EXISTS pluto_latest_districts_25a;
+CREATE TABLE IF NOT EXISTS pluto_latest_districts_25a AS (
+	SELECT
+		p.bbl,
+		p.address,
+		p.zipcode,
+		p.borough,
+		p.community_dist,
+		p.coun_dist,
+		p.boroct2020,
+		p.nta2020, 
+		p.nta2020_name,
+		ad.assemdist::text AS assem_dist,
+		ss.stsendist::text AS stsen_dist,
+		cg.congdist::text AS cong_dist,
+		p.geom
+	FROM x_pluto_geom AS p
+	LEFT JOIN nyad_25a AS ad ON ST_Within(p.geom, ad.geom)
+	LEFT JOIN nyss_25a AS ss ON ST_Within(p.geom, ss.geom)
+	LEFT JOIN nycg_25a AS cg ON ST_Within(p.geom, cg.geom)
+);
+
+CREATE INDEX pluto_latest_districts_25a_bbl_idx ON pluto_latest_districts_25a (bbl);
+CREATE INDEX pluto_latest_districts_25a_geom_idx ON pluto_latest_districts_25a using gist (geom);

--- a/src/nycdb/sql/pluto_latest_districts_25a.sql
+++ b/src/nycdb/sql/pluto_latest_districts_25a.sql
@@ -23,7 +23,6 @@ CREATE TEMP TABLE IF NOT EXISTS x_pluto_geom AS (
 
 CREATE INDEX ON x_pluto_geom using gist (geom);
 
-DROP TABLE IF EXISTS pluto_latest_districts_25a;
 CREATE TABLE IF NOT EXISTS pluto_latest_districts_25a AS (
 	SELECT
 		p.bbl,

--- a/src/tests/integration/test_nycdb.py
+++ b/src/tests/integration/test_nycdb.py
@@ -1018,3 +1018,28 @@ def test_executed_evictions(conn):
         rec = curs.fetchone()
         assert rec is not None
         assert rec['executeddate'].strftime("%Y-%m-%d") == '2024-02-26'
+
+
+def test_pluto_latest_districts(conn):
+    dataset_names = ["pluto_latest", "boundaries_25a", "pluto_latest_districts"]
+    for dataset_name in dataset_names:
+        dataset = nycdb.Dataset(dataset_name, args=ARGS)
+        dataset.drop()
+        dataset.db_import()
+
+    assert row_count(conn, "pluto_latest_districts") == 5
+    assert has_one_row(conn, "select 1 where to_regclass('public.pluto_latest_districts_bbl_idx') is NOT NULL")
+    assert has_one_row(conn, "select 1 where to_regclass('public.pluto_latest_districts_geom_idx') is NOT NULL")
+
+
+
+def test_pluto_latest_districts_25a(conn):
+    dataset_names = ["pluto_latest", "boundaries_25a", "pluto_latest_districts_25a"]
+    for dataset_name in dataset_names:
+        dataset = nycdb.Dataset(dataset_name, args=ARGS)
+        dataset.drop()
+        dataset.db_import()
+
+    assert row_count(conn, "pluto_latest_districts_25a") == 5
+    assert has_one_row(conn, "select 1 where to_regclass('public.pluto_latest_districts_25a_bbl_idx') is NOT NULL")
+    assert has_one_row(conn, "select 1 where to_regclass('public.pluto_latest_districts_25a_geom_idx') is NOT NULL")

--- a/src/tests/integration/test_nycdb.py
+++ b/src/tests/integration/test_nycdb.py
@@ -1031,6 +1031,16 @@ def test_pluto_latest_districts(conn):
     assert has_one_row(conn, "select 1 where to_regclass('public.pluto_latest_districts_bbl_idx') is NOT NULL")
     assert has_one_row(conn, "select 1 where to_regclass('public.pluto_latest_districts_geom_idx') is NOT NULL")
 
+def test_pluto_latest_districts_fails_without_depdendencies(conn):
+    dataset_names = ["pluto_latest", "boundaries_25a", "pluto_latest_districts"]
+    for dataset_name in dataset_names:
+        dataset = nycdb.Dataset(dataset_name, args=ARGS)
+        dataset.drop()
+
+    with pytest.raises(Exception) as excinfo:
+        dataset = nycdb.Dataset("pluto_latest_districts", args=ARGS)
+        dataset.db_import()
+    assert "Missing dataset dependency" in str(excinfo.value)
 
 
 def test_pluto_latest_districts_25a(conn):


### PR DESCRIPTION
This adds two new datasets that are solely based on SQL scripts and other nycdb datasets, with no source data downloaded. This is a new pattern, and required some small changes to skip standard processes like creating the empty table before import. It also adds a new section to the dataset yml files to list other nycdb datasets as dependencies, which are checked before the "import" step runs. 

The tables that are created via SQL are still listed in the yml schema so that the `--drop` and `--verify` commands still works, there just is no `fields` section for those schemas.
