### PR TITLE
List sql/data subdirectories in packages to silence build warnings

### DIFF
--- a/src/pyproject.toml
+++ b/src/pyproject.toml
@@ -36,7 +36,18 @@ requires = ["setuptools >= 61"]
 build-backend = "setuptools.build_meta"
 
 [tool.setuptools]
-packages = ["nycdb"]
+# Explicitly list every sql/yml-bearing directory so setuptools doesn't warn
+# that "Package would be ignored" (see #284). nycdb/datasets and nycdb/sql/*
+# don't have __init__.py and only hold data files, but setuptools' build_py
+# step still flags them as implicit namespace packages absent from the list.
+packages = [
+    "nycdb",
+    "nycdb.datasets",
+    "nycdb.sql",
+    "nycdb.sql.dobjobs",
+    "nycdb.sql.hpd_registrations",
+    "nycdb.sql.oca",
+]
 
 [tool.setuptools.package-data]
 nycdb =  ["datasets/*.yml", "sql/*.sql", "sql/**/*.sql"]


### PR DESCRIPTION
Closes #284.

`python3 -m build` was warning that `nycdb.datasets`, `nycdb.sql`, and the three `sql/` subdirectories (`dobjobs`, `hpd_registrations`, `oca`) were absent from the packages configuration. They don't have `__init__.py` and only hold data files, but setuptools' `build_py` step still treats them as implicit namespace packages and emits the 'Package would be ignored' warning for each one.

Listed them in `[tool.setuptools].packages` so the warnings go away. The built wheel still ships the same set of `.yml` and `.sql` files via the existing `package-data` glob (verified by unzipping `dist/nycdb-*-py3-none-any.whl`).