### PR TITLE
download_file: narrow bare except, include cause in message

### DIFF
--- a/src/nycdb/file.py
+++ b/src/nycdb/file.py
@@ -70,8 +70,8 @@ def download_file(url, dest, hide_progress=False):
                         f.write(chunk)
         pbar.close()
         return True
-    except:
-        raise DownloadFailedException("Could not download: {}".format(url))
+    except (requests.RequestException, OSError) as e:
+        raise DownloadFailedException("Could not download {}: {}".format(url, e))
 
 
 class File:


### PR DESCRIPTION
The bare except converted Ctrl+C (and bugs in the success path) into a plain `Could not download` message, hiding both the original traceback and the user's interrupt. Catching the network and OS errors that actually fire here, and including the exception in the message, makes a failed download easier to debug.