### PR TITLE
update indexes for PAD addresses

### DIFF
--- a/src/nycdb/sql/pad.sql
+++ b/src/nycdb/sql/pad.sql
@@ -1,2 +1,5 @@
-CREATE INDEX on pad_adr (bbl);
-CREATE INDEX on pad_adr (bin);
+CREATE INDEX ON pad_adr (bin);
+
+CREATE INDEX ON pad_adr (bbl, lhnd, stname)
+WHERE NULLIF(TRIM(lhnd), '') IS NOT NULL
+  AND NULLIF(TRIM(stname), '') IS NOT NULL;


### PR DESCRIPTION
At JustFix we're working on adding alternative addresses on who-owns-what building pages and it requires some queries on `pad_adr` and this will speed those up. Regular queries on just bbl should still be just as fast with this composite version, so I'm replacing the existing bbl-only one rather than adding a brand new one. 